### PR TITLE
CLINIC-140 (2):Revisar todas las variables que el linter marcar como useless

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -26,6 +26,6 @@ jobs:
         run: npm run format -- --check
         working-directory: frontend-app
 
-#     - name: Validar lint
-#         run: npm run lint
-#         working-directory: frontend-app
+      - name: Validar lint
+        run: npm run lint
+        working-directory: frontend-app

--- a/frontend-app/eslint.config.js
+++ b/frontend-app/eslint.config.js
@@ -1,8 +1,11 @@
+// eslint.config.js (ESLint flat config)
 import js from "@eslint/js";
 import vue from "eslint-plugin-vue";
 import vueParser from "vue-eslint-parser";
+import globals from "globals";
 
 export default [
+  // Ignora artefactos de build y reportes
   {
     ignores: [
       "**/node_modules/**",
@@ -14,52 +17,82 @@ export default [
       "source/playwright/**"
     ],
   },
+
+  // Reglas base JS + Vue
   js.configs.recommended,
   ...vue.configs["flat/recommended"],
+
+  // ✅ Globales de navegador para TODO el código de app (js,ts,vue)
+  {
+    files: ["**/*.{js,ts,vue}"],
+    languageOptions: {
+      // Para .vue, el parser lo pone el config de Vue; para .js usa espree (default)
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: "module",
+      },
+      globals: {
+        ...globals.browser, // window, document, etc.
+        fetch: true,
+        URL: true,
+        Blob: true,
+        File: true,
+        FormData: true,
+        atob: true,
+        localStorage: true,
+        setTimeout: true,
+        clearTimeout: true,
+        console: true,
+        alert: true,
+        confirm: true,
+      },
+    },
+  },
+
+  // Parser para SFC de Vue y reglas de estilo específicas
   {
     files: ["**/*.vue"],
     languageOptions: {
       parser: vueParser,
       parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: 2022,
         sourceType: "module",
-      },
-      globals: {
-        window: true,
-        document: true,
-        console: true,
-        fetch: true,
-        alert: true,
-        confirm: true,
-        localStorage: true,
-        setTimeout: true,
-        clearTimeout: true,
-        URL: true,
-        atob: true,
-        File: true,
-        Blob: true,
       },
     },
     plugins: { vue },
     rules: {
-      // Reglas recomendadas para Vue 3 según eslint-plugin-vue v10
+      // Tus reglas + pequeños ajustes para bajar ruido en CI
       "vue/no-unused-vars": "warn",
       "vue/no-mutating-props": "warn",
       "vue/no-unused-components": "warn",
       "vue/no-template-shadow": "warn",
       "vue/require-v-for-key": "error",
       "vue/require-valid-default-prop": "warn",
+
+      // Estilo (ajústalas a tu gusto)
       "vue/attribute-hyphenation": ["error", "never"],
-      "vue/html-self-closing": [
-        "error",
-        {
-          html: {
-            void: "always",
-            normal: "never",
-            component: "always",
-          },
-        },
-      ],
+      "vue/html-self-closing": ["error", {
+        html: { void: "always", normal: "never", component: "always" },
+      }],
+      "vue/max-attributes-per-line": ["warn", {
+        singleline: 3,
+        multiline: { max: 1, allowFirstLine: true },
+      }],
+      "vue/html-indent": ["warn", 2],
+      "vue/singleline-html-element-content-newline": "off",
+    },
+  },
+
+  // Archivos de Node/configuración (vite, scripts, etc.)
+  {
+    files: [
+      "**/*.config.*",
+      "vite.config.*",
+      "scripts/**",
+      ".eslintrc.*",
+    ],
+    languageOptions: {
+      globals: globals.node,
     },
   },
 ];

--- a/frontend-app/eslint.config.js
+++ b/frontend-app/eslint.config.js
@@ -1,98 +1,59 @@
-// eslint.config.js (ESLint flat config)
+// eslint.config.js
 import js from "@eslint/js";
 import vue from "eslint-plugin-vue";
 import vueParser from "vue-eslint-parser";
-import globals from "globals";
 
 export default [
-  // Ignora artefactos de build y reportes
   {
     ignores: [
-      "**/node_modules/**",
-      "**/dist/**",
-      "**/build/**",
-      "**/coverage/**",
-      "**/.vite/**",
-      "**/playwright-report/**",
-      "source/playwright/**"
+      "**/node_modules/**","**/dist/**","**/build/**","**/coverage/**",
+      "**/.vite/**","**/playwright-report/**","source/playwright/**"
     ],
   },
 
-  // Reglas base JS + Vue
   js.configs.recommended,
   ...vue.configs["flat/recommended"],
 
-  // ✅ Globales de navegador para TODO el código de app (js,ts,vue)
   {
     files: ["**/*.{js,ts,vue}"],
     languageOptions: {
-      // Para .vue, el parser lo pone el config de Vue; para .js usa espree (default)
-      parserOptions: {
-        ecmaVersion: 2022,
-        sourceType: "module",
-      },
+      parserOptions: { ecmaVersion: 2022, sourceType: "module" },
       globals: {
-        ...globals.browser, // window, document, etc.
-        fetch: true,
-        URL: true,
-        Blob: true,
-        File: true,
-        FormData: true,
-        atob: true,
-        localStorage: true,
-        setTimeout: true,
-        clearTimeout: true,
-        console: true,
-        alert: true,
-        confirm: true,
+        window: true, document: true, console: true,
+        fetch: true, URL: true, Blob: true, File: true, FormData: true, atob: true, btoa: true,
+        localStorage: true, setTimeout: true, clearTimeout: true,
+        alert: true, confirm: true,
       },
     },
   },
 
-  // Parser para SFC de Vue y reglas de estilo específicas
   {
     files: ["**/*.vue"],
     languageOptions: {
       parser: vueParser,
-      parserOptions: {
-        ecmaVersion: 2022,
-        sourceType: "module",
-      },
+      parserOptions: { ecmaVersion: 2022, sourceType: "module" },
     },
     plugins: { vue },
     rules: {
-      // Tus reglas + pequeños ajustes para bajar ruido en CI
       "vue/no-unused-vars": "warn",
       "vue/no-mutating-props": "warn",
       "vue/no-unused-components": "warn",
       "vue/no-template-shadow": "warn",
       "vue/require-v-for-key": "error",
       "vue/require-valid-default-prop": "warn",
-
-      // Estilo (ajústalas a tu gusto)
       "vue/attribute-hyphenation": ["error", "never"],
-      "vue/html-self-closing": ["error", {
-        html: { void: "always", normal: "never", component: "always" },
-      }],
-      "vue/max-attributes-per-line": ["warn", {
-        singleline: 3,
-        multiline: { max: 1, allowFirstLine: true },
-      }],
+      "vue/html-self-closing": ["error", { html: { void: "always", normal: "never", component: "always" } }],
+      // 👇 cambio aquí
+      "vue/max-attributes-per-line": ["warn", { singleline: 3, multiline: 1 }],
       "vue/html-indent": ["warn", 2],
       "vue/singleline-html-element-content-newline": "off",
     },
   },
 
-  // Archivos de Node/configuración (vite, scripts, etc.)
   {
-    files: [
-      "**/*.config.*",
-      "vite.config.*",
-      "scripts/**",
-      ".eslintrc.*",
-    ],
+    files: ["**/*.config.*","vite.config.*","scripts/**",".eslintrc.*"],
     languageOptions: {
-      globals: globals.node,
+      globals: { module: true, require: true, __dirname: true, process: true }
     },
   },
 ];

--- a/frontend-app/eslint.config.js
+++ b/frontend-app/eslint.config.js
@@ -3,7 +3,19 @@ import vue from "eslint-plugin-vue";
 import vueParser from "vue-eslint-parser";
 
 export default [
+  {
+    ignores: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/build/**",
+      "**/coverage/**",
+      "**/.vite/**",
+      "**/playwright-report/**",
+      "source/playwright/**"
+    ],
+  },
   js.configs.recommended,
+  ...vue.configs["flat/recommended"],
   {
     files: ["**/*.vue"],
     languageOptions: {

--- a/frontend-app/package-lock.json
+++ b/frontend-app/package-lock.json
@@ -28,15 +28,20 @@
         "zod": "^3.24.3"
       },
       "devDependencies": {
+        "@babel/eslint-parser": "^7.28.0",
+        "@eslint/js": "^9.34.0",
         "@pinia/testing": "^1.0.2",
+        "@playwright/experimental-ct-vue": "^1.55.0",
+        "@playwright/test": "^1.55.0",
         "@testing-library/vue": "^8.1.0",
+        "@types/node": "^24.3.0",
         "@vitejs/plugin-vue": "^5.2.1",
         "@vitest/ui": "3.2.4",
         "@vue/eslint-config-prettier": "^10.2.0",
         "@vue/test-utils": "^2.4.6",
         "autoprefixer": "^10.4.21",
         "eslint": "^9.31.0",
-        "eslint-plugin-vue": "^10.3.0",
+        "eslint-plugin-vue": "^10.4.0",
         "flush-promises": "^1.0.2",
         "jsdom": "^26.1.0",
         "postcss": "^8.5.3",
@@ -44,7 +49,8 @@
         "tailwindcss": "^3.4.17",
         "vite": "^6.2.0",
         "vite-plugin-vue-devtools": "^7.7.6",
-        "vitest": "^3.2.4"
+        "vitest": "^3.2.4",
+        "vue-eslint-parser": "^10.2.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -94,6 +100,12 @@
         "lru-cache": "^10.4.3"
       }
     },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.26.2",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
@@ -107,12 +119,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@babel/code-frame/node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
     },
     "node_modules/@babel/compat-data": {
       "version": "7.26.8",
@@ -153,13 +159,22 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+    "node_modules/@babel/eslint-parser": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.28.0.tgz",
+      "integrity": "sha512-N4ntErOlKvcbTt01rr5wj3y55xnIdx1ymrfIr8C2WnM1Y9glFgWaGDEULJIazOX3XM9NRzhfJ6zZnQ1sBNWU+w==",
       "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
+      "dependencies": {
+        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0",
+        "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
       }
     },
     "node_modules/@babel/generator": {
@@ -206,24 +221,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.0.tgz",
@@ -243,15 +240,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
@@ -352,7 +340,6 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
       "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -361,7 +348,6 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
       "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -392,7 +378,6 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
       "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
-      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.27.0"
       },
@@ -516,7 +501,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
       "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -557,7 +541,6 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
       "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"
@@ -684,7 +667,6 @@
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
@@ -701,7 +683,6 @@
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -718,7 +699,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -735,7 +715,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -752,7 +731,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -769,7 +747,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -786,7 +763,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -803,7 +779,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -820,7 +795,6 @@
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -837,7 +811,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -854,7 +827,6 @@
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -871,7 +843,6 @@
         "loong64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -888,7 +859,6 @@
         "mips64el"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -905,7 +875,6 @@
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -922,7 +891,6 @@
         "riscv64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -939,7 +907,6 @@
         "s390x"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -956,7 +923,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -973,7 +939,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -990,7 +955,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -1007,7 +971,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -1024,7 +987,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -1041,7 +1003,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -1058,7 +1019,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1075,7 +1035,6 @@
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1092,7 +1051,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1106,7 +1064,6 @@
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
       "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
@@ -1125,7 +1082,6 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -1138,7 +1094,6 @@
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
       "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -1148,7 +1103,6 @@
       "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
       "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.6",
         "debug": "^4.3.1",
@@ -1158,36 +1112,11 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/@eslint/config-helpers": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
       "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -1197,7 +1126,6 @@
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
       "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -1210,7 +1138,6 @@
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
       "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -1229,23 +1156,11 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1253,35 +1168,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/@eslint/js": {
-      "version": "9.32.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.32.0.tgz",
-      "integrity": "sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==",
+      "version": "9.34.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.34.0.tgz",
+      "integrity": "sha512-EoyvqQnBNsV1CWaEJ559rxXL4c8V92gxirbawSmVUOWXlsRxxQXl6LmCpdUblgxgSkDIqKnhzba2SjRTI/A5Rw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1294,7 +1185,6 @@
       "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
       "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -1304,7 +1194,6 @@
       "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
       "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"
@@ -1317,7 +1206,6 @@
       "version": "6.1.17",
       "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.17.tgz",
       "integrity": "sha512-0W7lnIrv18ruJ5zeWBeNZXO8qCWlzxDdp9COFEsZnyNjiEhUVnrW/dPbjRKYpL0edGG0/Lhs0ghp1z/5ekt8ZA==",
-      "license": "MIT",
       "dependencies": {
         "preact": "~10.12.1"
       }
@@ -1326,7 +1214,6 @@
       "version": "6.1.17",
       "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.17.tgz",
       "integrity": "sha512-K7m+pd7oVJ9fW4h7CLDdDGJbc9szJ1xDU1DZ2ag+7oOo1aCNLv44CehzkkknM6r8EYlOOhgaelxQpKAI4glj7A==",
-      "license": "MIT",
       "peerDependencies": {
         "@fullcalendar/core": "~6.1.17"
       }
@@ -1335,7 +1222,6 @@
       "version": "6.1.17",
       "resolved": "https://registry.npmjs.org/@fullcalendar/vue3/-/vue3-6.1.17.tgz",
       "integrity": "sha512-0+qi/PK/xCkTQXh2CaeN2AkP+SvQTznPhwBXuIyrtsR0Ua8UpmGEXI+my3qQ6o003r8gPUY2e785ywIyhX2zCA==",
-      "license": "MIT",
       "peerDependencies": {
         "@fullcalendar/core": "~6.1.17",
         "vue": "^3.0.11"
@@ -1368,7 +1254,6 @@
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -1378,7 +1263,6 @@
       "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
       "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/core": "^0.19.1",
         "@humanwhocodes/retry": "^0.3.0"
@@ -1392,7 +1276,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
       "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
       },
@@ -1406,7 +1289,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
       },
@@ -1420,7 +1302,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
       },
@@ -1522,8 +1403,7 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "license": "MIT"
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -1533,6 +1413,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
+      "version": "5.1.1-v1",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
+      "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
+      "dev": true,
+      "dependencies": {
+        "eslint-scope": "5.1.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1599,12 +1488,23 @@
         "node": ">=18.12.0"
       }
     },
-    "node_modules/@nuxt/kit/node_modules/jiti": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+    "node_modules/@nuxt/kit/node_modules/ignore": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.3.tgz",
+      "integrity": "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@nuxt/kit/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "bin": {
-        "jiti": "lib/jiti-cli.mjs"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@one-ini/wasm": {
@@ -1618,7 +1518,6 @@
       "resolved": "https://registry.npmjs.org/@pinia/testing/-/testing-1.0.2.tgz",
       "integrity": "sha512-yZVXJTKh677J0AT8kOPxGk5s1v7hMQIDT3tmeriwtR5LDu41DvXTEBQf0ql9SsHW1mCSDG38QDFzSSl5ucJqnQ==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/posva"
       },
@@ -1641,12 +1540,56 @@
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
       "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/experimental-ct-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/experimental-ct-core/-/experimental-ct-core-1.55.0.tgz",
+      "integrity": "sha512-8HRI8Envzgv3bVr6CrKCW3NxFR3dvXaE10OACkfs50GiTn5t4m31UJ3wDpFAgzxZvXPoyLfG3mLG16YbpWS5Ww==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.55.0",
+        "playwright-core": "1.55.0",
+        "vite": "^6.3.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/experimental-ct-vue": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/experimental-ct-vue/-/experimental-ct-vue-1.55.0.tgz",
+      "integrity": "sha512-971Ckf1xX/9CDXAz8kNNLJRKyve8aIbqJpJULqCr46cP80PrJbp7yDG9CIb7aRxwmvrheZagTMrkc+Zvw49b2g==",
+      "dev": true,
+      "dependencies": {
+        "@playwright/experimental-ct-core": "1.55.0",
+        "@vitejs/plugin-vue": "^5.2.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -1677,6 +1620,12 @@
         }
       }
     },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
     "node_modules/@rollup/pluginutils/node_modules/picomatch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
@@ -1697,7 +1646,6 @@
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -1711,7 +1659,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -1725,7 +1672,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1739,7 +1685,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1753,7 +1698,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -1767,7 +1711,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -1781,7 +1724,6 @@
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1795,7 +1737,6 @@
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1809,7 +1750,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1823,7 +1763,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1837,7 +1776,6 @@
         "loong64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1851,7 +1789,6 @@
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1865,7 +1802,6 @@
         "riscv64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1879,7 +1815,6 @@
         "riscv64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1893,7 +1828,6 @@
         "s390x"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1907,7 +1841,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1921,7 +1854,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1935,7 +1867,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1949,7 +1880,6 @@
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1963,7 +1893,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2015,7 +1944,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
       "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2035,7 +1963,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/vue/-/vue-8.1.0.tgz",
       "integrity": "sha512-ls4RiHO1ta4mxqqajWRh8158uFObVrrtAPoxk7cIp4HrnQUj/ScKzqz53HxYpG3X6Zb7H2v+0eTGLSoy8HQ2nA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2",
         "@testing-library/dom": "^9.3.3",
@@ -2058,8 +1985,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.2",
@@ -2079,15 +2005,22 @@
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
-      "license": "MIT"
+      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
       "dev": true,
-      "license": "MIT"
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
     },
     "node_modules/@vee-validate/zod": {
       "version": "4.15.0",
@@ -2105,7 +2038,6 @@
       "version": "4.15.0",
       "resolved": "https://registry.npmjs.org/vee-validate/-/vee-validate-4.15.0.tgz",
       "integrity": "sha512-PGJh1QCFwCBjbHu5aN6vB8macYVWrajbDvgo1Y/8fz9n/RVIkLmZCJDpUgu7+mUmCOPMxeyq7vXUOhbwAqdXcA==",
-      "license": "MIT",
       "dependencies": {
         "@vue/devtools-api": "^7.5.2",
         "type-fest": "^4.8.3"
@@ -2119,7 +2051,6 @@
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.3.tgz",
       "integrity": "sha512-IYSLEQj4LgZZuoVpdSUCw3dIynTWQgPlaRP6iAvMle4My0HdYwr5g5wQAfwOeHQBmYwEkqF70nRpSilr6PoUDg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
       },
@@ -2168,15 +2099,6 @@
         "vite": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@vitest/mocker/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/@vitest/pretty-format": {
@@ -2236,7 +2158,6 @@
       "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.4.tgz",
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -2321,7 +2242,6 @@
       "version": "3.5.13",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
       "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
-      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.3",
         "@vue/shared": "3.5.13",
@@ -2330,11 +2250,26 @@
         "source-map-js": "^1.2.0"
       }
     },
+    "node_modules/@vue/compiler-core/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+    },
     "node_modules/@vue/compiler-dom": {
       "version": "3.5.13",
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
       "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
-      "license": "MIT",
       "dependencies": {
         "@vue/compiler-core": "3.5.13",
         "@vue/shared": "3.5.13"
@@ -2344,7 +2279,6 @@
       "version": "3.5.13",
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz",
       "integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
-      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.3",
         "@vue/compiler-core": "3.5.13",
@@ -2357,11 +2291,15 @@
         "source-map-js": "^1.2.0"
       }
     },
+    "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+    },
     "node_modules/@vue/compiler-ssr": {
       "version": "3.5.13",
       "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
       "integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
-      "license": "MIT",
       "dependencies": {
         "@vue/compiler-dom": "3.5.13",
         "@vue/shared": "3.5.13"
@@ -2380,7 +2318,6 @@
       "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-7.7.6.tgz",
       "integrity": "sha512-ghVX3zjKPtSHu94Xs03giRIeIWlb9M+gvDRVpIZ/cRIxKHdW6HE/sm1PT3rUYS3aV92CazirT93ne+7IOvGUWg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@vue/devtools-kit": "^7.7.6",
         "@vue/devtools-shared": "^7.7.6",
@@ -2404,7 +2341,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.js"
       },
@@ -2416,7 +2352,6 @@
       "version": "7.7.6",
       "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.6.tgz",
       "integrity": "sha512-geu7ds7tem2Y7Wz+WgbnbZ6T5eadOvozHZ23Atk/8tksHMFOFylKi1xgGlQlVn0wlkEf4hu+vd5ctj1G4kFtwA==",
-      "license": "MIT",
       "dependencies": {
         "@vue/devtools-shared": "^7.7.6",
         "birpc": "^2.3.0",
@@ -2431,7 +2366,6 @@
       "version": "7.7.6",
       "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.6.tgz",
       "integrity": "sha512-yFEgJZ/WblEsojQQceuyK6FzpFDx4kqrz2ohInxNj5/DnhoX023upTv4OD6lNPLAA5LLkbwPVb10o/7b+Y4FVA==",
-      "license": "MIT",
       "dependencies": {
         "rfdc": "^1.4.1"
       }
@@ -2441,7 +2375,6 @@
       "resolved": "https://registry.npmjs.org/@vue/eslint-config-prettier/-/eslint-config-prettier-10.2.0.tgz",
       "integrity": "sha512-GL3YBLwv/+b86yHcNNfPJxOTtVFJ4Mbc9UU3zR+KVoG7SwGTjPT+32fXamscNumElhcpXW3mT0DgzS9w32S7Bw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.2.2"
@@ -2455,7 +2388,6 @@
       "version": "3.5.13",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.13.tgz",
       "integrity": "sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==",
-      "license": "MIT",
       "dependencies": {
         "@vue/shared": "3.5.13"
       }
@@ -2464,7 +2396,6 @@
       "version": "3.5.13",
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.13.tgz",
       "integrity": "sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==",
-      "license": "MIT",
       "dependencies": {
         "@vue/reactivity": "3.5.13",
         "@vue/shared": "3.5.13"
@@ -2474,7 +2405,6 @@
       "version": "3.5.13",
       "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.13.tgz",
       "integrity": "sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==",
-      "license": "MIT",
       "dependencies": {
         "@vue/reactivity": "3.5.13",
         "@vue/runtime-core": "3.5.13",
@@ -2486,7 +2416,6 @@
       "version": "3.5.13",
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.13.tgz",
       "integrity": "sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==",
-      "license": "MIT",
       "dependencies": {
         "@vue/compiler-ssr": "3.5.13",
         "@vue/shared": "3.5.13"
@@ -2498,15 +2427,13 @@
     "node_modules/@vue/shared": {
       "version": "3.5.13",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
-      "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
-      "license": "MIT"
+      "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ=="
     },
     "node_modules/@vue/test-utils": {
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.6.tgz",
       "integrity": "sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "js-beautify": "^1.14.9",
         "vue-component-type-helpers": "^2.0.0"
@@ -2525,7 +2452,6 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2538,7 +2464,6 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -2557,7 +2482,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2570,24 +2494,24 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -2622,15 +2546,13 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
+      "dev": true
     },
     "node_modules/aria-query": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
       "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "deep-equal": "^2.0.5"
       }
@@ -2640,7 +2562,6 @@
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
       "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
         "is-array-buffer": "^3.0.5"
@@ -2664,8 +2585,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
@@ -2709,7 +2629,6 @@
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
       },
@@ -2724,7 +2643,6 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
       "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
-      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -2761,16 +2679,16 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
@@ -2858,40 +2776,6 @@
         }
       }
     },
-    "node_modules/c12/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/c12/node_modules/jiti": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/c12/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -2906,7 +2790,6 @@
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
@@ -2924,7 +2807,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -2938,7 +2820,6 @@
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -2955,7 +2836,6 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -3010,7 +2890,6 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3020,22 +2899,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/check-error": {
@@ -3048,39 +2911,17 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
+        "readdirp": "^4.0.1"
       },
       "engines": {
-        "node": ">= 8.10.0"
+        "node": ">= 14.16.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/citty": {
@@ -3113,7 +2954,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3122,20 +2962,19 @@
       }
     },
     "node_modules/commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
       "dev": true,
       "engines": {
-        "node": ">= 6"
+        "node": ">=14"
       }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/confbox": {
       "version": "0.2.2",
@@ -3222,8 +3061,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT"
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -3242,7 +3080,6 @@
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/dayspan/-/dayspan-0.12.5.tgz",
       "integrity": "sha512-/IkvULBqTRJjUnmKcu3nAGpo04mIszC+ua1ItZadNRxfMKzplmxEljHytOpHdOyl6GF3V7de8oxgep7emeivNA==",
-      "license": "MIT",
       "engines": {
         "node": ">=6.9"
       },
@@ -3254,7 +3091,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/dayspan-vuetify/-/dayspan-vuetify-0.4.0.tgz",
       "integrity": "sha512-YoCFu1hZsvklDQXm8IBRvY00v/B06F/h6yS0k4GALEqrzlqY0EKF4UUdjlr5xMRoKuw7NTA//4V4twOQ8H3D/A==",
-      "license": "MIT",
       "dependencies": {
         "dayspan": "^0.12.2",
         "material-design-icons-iconfont": "^3.0.3",
@@ -3283,7 +3119,6 @@
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "license": "MIT",
       "optional": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -3300,7 +3135,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.16.tgz",
       "integrity": "sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==",
       "deprecated": "Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.",
-      "license": "MIT",
       "dependencies": {
         "@vue/compiler-sfc": "2.7.16",
         "csstype": "^3.1.0"
@@ -3310,7 +3144,6 @@
       "version": "1.5.23",
       "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-1.5.23.tgz",
       "integrity": "sha512-T6ZAli8jWHRsDIjQmB4UG4iXJtwH1M+H5/8Cd76m6XKcic93R6qnKI1IK9OFIVqcrZc1Iw1kDeQWG35iQt0M2Q==",
-      "license": "MIT",
       "peerDependencies": {
         "vue": "^2.5.18"
       }
@@ -3352,7 +3185,6 @@
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
       "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.0",
         "call-bind": "^1.0.5",
@@ -3384,8 +3216,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/deep-pick-omit": {
       "version": "1.2.1",
@@ -3425,7 +3256,6 @@
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -3455,7 +3285,6 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -3477,7 +3306,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3503,8 +3331,7 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/dotenv": {
       "version": "16.5.0",
@@ -3521,7 +3348,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -3555,13 +3381,13 @@
         "node": ">=14"
       }
     },
-    "node_modules/editorconfig/node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+    "node_modules/editorconfig/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
-      "engines": {
-        "node": ">=14"
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/editorconfig/node_modules/minimatch": {
@@ -3579,6 +3405,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/editorconfig/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.140",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.140.tgz",
@@ -3592,10 +3430,10 @@
       "dev": true
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -3621,7 +3459,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -3630,7 +3467,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -3640,7 +3476,6 @@
       "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
       "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.3",
@@ -3666,7 +3501,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -3678,7 +3512,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -3695,7 +3528,6 @@
       "integrity": "sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3740,11 +3572,12 @@
       }
     },
     "node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3755,7 +3588,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz",
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3816,7 +3648,6 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -3832,7 +3663,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.3.tgz",
       "integrity": "sha512-NAdMYww51ehKfDyDhv59/eIItUVzU0Io9H2E8nHNGKEeeqlnci+1gCvrHib6EmZdf6GxF+LCV5K7UC65Ezvw7w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "prettier-linter-helpers": "^1.0.0",
         "synckit": "^0.11.7"
@@ -3863,7 +3693,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.4.0.tgz",
       "integrity": "sha512-K6tP0dW8FJVZLQxa2S7LcE1lLw3X8VvB3t887Q6CLrFVxHYBXGANbXvwNzYIu6Ughx1bSJ5BDT0YB3ybPT39lw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "natural-compare": "^1.4.0",
@@ -3886,22 +3715,57 @@
         }
       }
     },
-    "node_modules/eslint-plugin-vue/node_modules/xml-name-validator": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+    "node_modules/eslint-plugin-vue/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
-      "license": "Apache-2.0",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       }
     },
     "node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "9.32.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.32.0.tgz",
+      "integrity": "sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
       "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -3913,12 +3777,11 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint-visitor-keys": {
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -3926,51 +3789,13 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+    "node_modules/eslint/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/eslint/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
+        "node": ">=4.0"
       }
     },
     "node_modules/espree": {
@@ -3978,7 +3803,6 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
       "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
@@ -3991,12 +3815,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
       "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -4004,12 +3839,20 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/esquery/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/esrecurse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -4017,28 +3860,37 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/estraverse": {
+    "node_modules/esrecurse/node_modules/estraverse": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
     },
     "node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "license": "MIT"
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
     },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4099,15 +3951,13 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-      "dev": true,
-      "license": "Apache-2.0"
+      "dev": true
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -4139,15 +3989,13 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -4161,8 +4009,7 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/figures": {
       "version": "6.1.0",
@@ -4184,7 +4031,6 @@
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "flat-cache": "^4.0.0"
       },
@@ -4208,7 +4054,6 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -4225,7 +4070,6 @@
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.4"
@@ -4238,15 +4082,13 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/flush-promises": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/flush-promises/-/flush-promises-1.0.2.tgz",
       "integrity": "sha512-G0sYfLQERwKz4+4iOZYQEZVpOt9zQrlItIxQAAYAWpfby3gbHrx0osCHz5RLl/XoXevXk0xoN4hDFky/VV9TrA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -4258,7 +4100,6 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -4273,7 +4114,6 @@
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
       },
@@ -4304,7 +4144,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
       "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -4344,12 +4183,11 @@
       }
     },
     "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -4371,7 +4209,6 @@
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4389,7 +4226,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -4413,7 +4249,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -4486,6 +4321,30 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -4514,11 +4373,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.3.tgz",
+      "integrity": "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4537,7 +4403,6 @@
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
       "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4550,7 +4415,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -4560,7 +4424,6 @@
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -4572,7 +4435,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4584,7 +4446,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -4671,9 +4532,10 @@
       }
     },
     "node_modules/ignore": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.3.tgz",
-      "integrity": "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -4683,7 +4545,6 @@
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -4700,7 +4561,6 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
       }
@@ -4716,7 +4576,6 @@
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
       "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "hasown": "^2.0.2",
@@ -4731,7 +4590,6 @@
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
       "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
@@ -4748,7 +4606,6 @@
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
       "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -4766,7 +4623,6 @@
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
       "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.2"
       },
@@ -4794,7 +4650,6 @@
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
       "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
@@ -4811,7 +4666,6 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4839,7 +4693,6 @@
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
       "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
@@ -4917,7 +4770,6 @@
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4938,7 +4790,6 @@
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
       "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
@@ -4973,7 +4824,6 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "gopd": "^1.2.0",
@@ -4992,7 +4842,6 @@
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
       "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -5005,7 +4854,6 @@
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
       "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
       },
@@ -5033,7 +4881,6 @@
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
       "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
@@ -5050,7 +4897,6 @@
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
       "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-symbols": "^1.1.0",
@@ -5080,7 +4926,6 @@
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -5093,7 +4938,6 @@
       "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
       "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
         "get-intrinsic": "^1.2.6"
@@ -5135,8 +4979,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5160,12 +5003,11 @@
       }
     },
     "node_modules/jiti": {
-      "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
       "bin": {
-        "jiti": "bin/jiti.js"
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/js-beautify": {
@@ -5199,16 +5041,16 @@
       }
     },
     "node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -5255,6 +5097,15 @@
         }
       }
     },
+    "node_modules/jsdom/node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -5271,22 +5122,19 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -5317,7 +5165,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -5346,7 +5193,6 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -5394,7 +5240,6 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -5409,8 +5254,7 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/loupe": {
       "version": "3.1.4",
@@ -5419,16 +5263,18 @@
       "dev": true
     },
     "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
     },
     "node_modules/luxon": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.1.tgz",
       "integrity": "sha512-RkRWjA926cTvz5rAb1BqyWkKbbjzCGchDUIKMCUvNi17j6f6j8uHGDV82Aqcqtzd+icoYpELmG3ksgGiFNNcNg==",
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
@@ -5438,7 +5284,6 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5447,7 +5292,6 @@
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
       "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
@@ -5455,14 +5299,12 @@
     "node_modules/material-design-icons-iconfont": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/material-design-icons-iconfont/-/material-design-icons-iconfont-3.0.3.tgz",
-      "integrity": "sha512-wbvGpfJGLDuL0bj9pFd4sjXvGqukKraViSFRVDLk97s/GrKs/rGv9Eo2286jkxfFqkYXczyJrglUZlbyfFVOFw==",
-      "license": "CC-BY-4.0"
+      "integrity": "sha512-wbvGpfJGLDuL0bj9pFd4sjXvGqukKraViSFRVDLk97s/GrKs/rGv9Eo2286jkxfFqkYXczyJrglUZlbyfFVOFw=="
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -5491,7 +5333,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -5500,7 +5341,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -5509,18 +5349,15 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^1.1.7"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": "*"
       }
     },
     "node_modules/minipass": {
@@ -5567,7 +5404,6 @@
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": "*"
@@ -5609,7 +5445,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -5621,8 +5456,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/node-fetch-native": {
       "version": "1.6.6",
@@ -5701,7 +5535,6 @@
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -5756,7 +5589,6 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -5769,7 +5601,6 @@
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
       "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1"
@@ -5786,7 +5617,6 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -5796,7 +5626,6 @@
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
       "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -5840,7 +5669,6 @@
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -5858,7 +5686,6 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -5874,7 +5701,6 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -5896,7 +5722,6 @@
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -5928,24 +5753,11 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/parse5/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -5981,6 +5793,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
     "node_modules/path-type": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
@@ -6014,8 +5832,7 @@
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "license": "ISC"
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -6041,7 +5858,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.3.tgz",
       "integrity": "sha512-ttXO/InUULUXkMHpTdp9Fj4hLpD/2AoJdmAbAeW2yu1iy1k+pkFekQXw5VpC0/5p51IOR/jDaDRfRWRnMMsGOA==",
-      "license": "MIT",
       "dependencies": {
         "@vue/devtools-api": "^7.7.2"
       },
@@ -6100,12 +5916,41 @@
         "pathe": "^2.0.3"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -6256,7 +6101,6 @@
       "version": "10.12.1",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
       "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -6267,7 +6111,6 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -6277,7 +6120,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6293,7 +6135,6 @@
       "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
       "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fast-diff": "^1.1.2"
       },
@@ -6306,7 +6147,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6316,22 +6156,11 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
-    "node_modules/pretty-format/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -6357,8 +6186,7 @@
     "node_modules/property-expr": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
-      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
-      "license": "MIT"
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA=="
     },
     "node_modules/proto-list": {
       "version": "1.2.4",
@@ -6369,8 +6197,7 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -6428,8 +6255,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -6441,15 +6267,15 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/regexp.prototype.flags": {
@@ -6457,7 +6283,6 @@
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
       "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
@@ -6498,7 +6323,6 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -6515,15 +6339,13 @@
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-      "license": "MIT"
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="
     },
     "node_modules/rollup": {
       "version": "4.39.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.39.0.tgz",
       "integrity": "sha512-thI8kNc02yNvnmJp8dr3fNWJ9tCONDhp6TV35X6HkKGGs9E6q7YWCHbe5vKiTa7TAiNcFEmXKj3X/pG2b3ci0g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.7"
       },
@@ -6603,7 +6425,6 @@
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -6640,14 +6461,12 @@
       "integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g=="
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/set-function-length": {
@@ -6655,7 +6474,6 @@
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -6673,7 +6491,6 @@
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -6710,7 +6527,6 @@
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -6730,7 +6546,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
@@ -6747,7 +6562,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -6766,7 +6580,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -6828,7 +6641,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6837,7 +6649,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6866,7 +6677,6 @@
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
       "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "internal-slot": "^1.1.0"
@@ -6903,15 +6713,6 @@
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6962,13 +6763,16 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/strip-final-newline": {
@@ -6988,7 +6792,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -7006,6 +6809,11 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="
     },
     "node_modules/sucrase": {
       "version": "3.35.0",
@@ -7029,6 +6837,15 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/superjson": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.2.tgz",
@@ -7045,7 +6862,6 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -7076,7 +6892,6 @@
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
       "integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@pkgr/core": "^0.2.9"
       },
@@ -7124,6 +6939,63 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tailwindcss/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -7148,8 +7020,7 @@
     "node_modules/tiny-case": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
-      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
-      "license": "MIT"
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q=="
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -7260,8 +7131,7 @@
     "node_modules/toposort": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
-      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
-      "license": "MIT"
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
     },
     "node_modules/totalist": {
       "version": "3.0.1",
@@ -7307,7 +7177,6 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -7342,13 +7211,11 @@
         "unplugin": "^2.1.0"
       }
     },
-    "node_modules/unctx/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true
     },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
@@ -7385,12 +7252,15 @@
         "node": ">=18.12.0"
       }
     },
-    "node_modules/unimport/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
+    "node_modules/unimport/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unimport/node_modules/picomatch": {
@@ -7478,14 +7348,6 @@
         "untyped": "dist/cli.mjs"
       }
     },
-    "node_modules/untyped/node_modules/jiti": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -7521,7 +7383,6 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -7536,7 +7397,6 @@
       "version": "4.15.1",
       "resolved": "https://registry.npmjs.org/vee-validate/-/vee-validate-4.15.1.tgz",
       "integrity": "sha512-DkFsiTwEKau8VIxyZBGdO6tOudD+QoUBPuHj3e6QFqmbfCRj1ArmYWue9lEp6jLSWBIw4XPlDLjFIZNLdRAMSg==",
-      "license": "MIT",
       "dependencies": {
         "@vue/devtools-api": "^7.5.2",
         "type-fest": "^4.8.3"
@@ -7546,15 +7406,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
-      "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
         "postcss": "^8.5.3",
-        "rollup": "^4.30.1"
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -7622,7 +7484,6 @@
       "resolved": "https://registry.npmjs.org/vite-hot-client/-/vite-hot-client-2.0.4.tgz",
       "integrity": "sha512-W9LOGAyGMrbGArYJN4LBCdOC5+Zwh7dHvOHC0KmGKkJhsOzaKbpo/jEjpPKVHIW0/jBWj8RZG0NUxfgA8BxgAg==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       },
@@ -7688,7 +7549,6 @@
       "resolved": "https://registry.npmjs.org/vite-plugin-vue-devtools/-/vite-plugin-vue-devtools-7.7.6.tgz",
       "integrity": "sha512-L7nPVM5a7lgit/Z+36iwoqHOaP3wxqVi1UvaDJwGCfblS9Y6vNqf32ILlzJVH9c47aHu90BhDXeZc+rgzHRHcw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@vue/devtools-core": "^7.7.6",
         "@vue/devtools-kit": "^7.7.6",
@@ -7725,12 +7585,51 @@
         "vite": "^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.0-0"
       }
     },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+      "dev": true,
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/vitest": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -7799,9 +7698,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -7814,7 +7713,6 @@
       "version": "3.5.13",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
       "integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
-      "license": "MIT",
       "dependencies": {
         "@vue/compiler-dom": "3.5.13",
         "@vue/compiler-sfc": "3.5.13",
@@ -7842,8 +7740,6 @@
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-10.2.0.tgz",
       "integrity": "sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0",
@@ -7860,6 +7756,55 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
+    "node_modules/vue-eslint-parser/node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/vue-eslint-parser/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/vue-eslint-parser/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/vue-eslint-parser/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/vue-i18n": {
@@ -7909,7 +7854,6 @@
       "version": "3.8.6",
       "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.8.6.tgz",
       "integrity": "sha512-WU7BrS0rKtewaU1e0SjJmUVc23k1Y9L5+aJdSmezAYlxYbHprlFVYeZZvwj1kA9xrPE8MGguvMQgePSxxD/l2w==",
-      "license": "MIT",
       "engines": {
         "node": "^12.20 || >=14.13"
       },
@@ -7943,6 +7887,15 @@
       "dependencies": {
         "xml-name-validator": "^5.0.0"
       },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/w3c-xmlserializer/node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
       "engines": {
         "node": ">=18"
       }
@@ -8015,7 +7968,6 @@
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
       "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.1.0",
         "is-boolean-object": "^1.2.1",
@@ -8035,7 +7987,6 @@
       "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
       "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-map": "^2.0.3",
         "is-set": "^2.0.3",
@@ -8054,7 +8005,6 @@
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
       "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",
@@ -8092,7 +8042,6 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8132,30 +8081,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -8188,6 +8113,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/ws": {
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
@@ -8210,12 +8147,12 @@
       }
     },
     "node_modules/xml-name-validator": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
-      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
       "dev": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/xmlchars": {
@@ -8247,7 +8184,6 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -8271,7 +8207,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/yup/-/yup-1.6.1.tgz",
       "integrity": "sha512-JED8pB50qbA4FOkDol0bYF/p60qSEDQqBD0/qeIrUCG1KbPBIQ776fCUNb9ldbPcSTxA69g/47XTo4TqWiuXOA==",
-      "license": "MIT",
       "dependencies": {
         "property-expr": "^2.0.5",
         "tiny-case": "^1.0.3",
@@ -8283,7 +8218,6 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=12.20"
       },

--- a/frontend-app/package.json
+++ b/frontend-app/package.json
@@ -52,7 +52,7 @@
     "@vue/test-utils": "^2.4.6",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.31.0",
-    "eslint-plugin-vue": "^10.3.0",
+    "eslint-plugin-vue": "^10.4.0",
     "flush-promises": "^1.0.2",
     "jsdom": "^26.1.0",
     "postcss": "^8.5.3",

--- a/frontend-app/src/App.vue
+++ b/frontend-app/src/App.vue
@@ -3,8 +3,8 @@
     <RouterView />
     <patients-create-form-dialog
       v-if="showCreateFormDialog"
-      @close="closeAllPatientDialog"
       :isOpen="showCreateFormDialog"
+      @close="closeAllPatientDialog"
     />
     <notification-alert />
   </div>
@@ -12,7 +12,7 @@
 
 <script setup>
 import { RouterView } from "vue-router";
-import { ref, onMounted, defineAsyncComponent } from "vue";
+import { defineAsyncComponent } from "vue";
 import { storeToRefs } from "pinia";
 import { usePatientsLogicStore } from "@stores/patientsLogicStore";
 

--- a/frontend-app/src/components/calendarComponents/CalendarMain.vue
+++ b/frontend-app/src/components/calendarComponents/CalendarMain.vue
@@ -3,11 +3,6 @@ import styles from "./CalendarMain.module.css";
 import { ref, watch, nextTick, computed } from "vue";
 import { onMounted } from "vue";
 
-// Puedes cambiar esto cuando tengas tu componente real
-const PatientSearch = {
-  template: `<input type="text" placeholder="Buscar paciente..." />`,
-};
-
 const today = new Date();
 const currentMonth = ref(today.getMonth());
 const currentYear = ref(today.getFullYear());
@@ -252,7 +247,7 @@ function startEdit(i, event) {
   );
 }
 
-function saveEdit(i) {
+function saveEdit() {
   if (editingEventId.value === null || editingEventId.value === -1) return;
   if (editingText.value && editingStart.value) {
     const event = events.value[editingEventId.value];
@@ -512,14 +507,20 @@ onMounted(() => {
 });
 </script>
 <template>
-  <div :class="styles['main-content']" data-testid="calendar-root">
+  <div
+    :class="styles['main-content']"
+    data-testid="calendar-root"
+  >
     <!-- Header del calendario -->
-    <div :class="styles['calendar-header']" data-testid="calendar-header">
+    <div
+      :class="styles['calendar-header']"
+      data-testid="calendar-header"
+    >
       <button
-        @click="prevMonth"
         :class="styles['calendar-btn']"
         data-testid="calendar-prev-btn"
         aria-label="Mes anterior"
+        @click="prevMonth"
       >
         &lt;
       </button>
@@ -528,9 +529,9 @@ onMounted(() => {
           monthNames[currentMonth]
         }}</span>
         <button
-          @click="showYearSelect = !showYearSelect"
           :class="styles['calendar-year-btn']"
           data-testid="calendar-year-btn"
+          @click="showYearSelect = !showYearSelect"
         >
           {{ currentYear }}
         </button>
@@ -542,28 +543,38 @@ onMounted(() => {
           <div
             v-for="year in years"
             :key="year"
-            @click="selectYear(year)"
             :class="styles['year-option']"
             :data-testid="`year-option-${year}`"
+            @click="selectYear(year)"
           >
             {{ year }}
           </div>
         </div>
       </div>
       <button
-        @click="nextMonth"
         :class="styles['calendar-btn']"
         data-testid="calendar-next-btn"
         aria-label="Mes siguiente"
+        @click="nextMonth"
       >
         &gt;
       </button>
     </div>
 
     <!-- Tabla del calendario -->
-    <div :class="styles['calendar-table']" data-testid="calendar-table">
-      <div :class="styles['calendar-row']" data-testid="calendar-days-header">
-        <div v-for="day in days" :key="day" :class="styles['calendar-day']">
+    <div
+      :class="styles['calendar-table']"
+      data-testid="calendar-table"
+    >
+      <div
+        :class="styles['calendar-row']"
+        data-testid="calendar-days-header"
+      >
+        <div
+          v-for="day in days"
+          :key="day"
+          :class="styles['calendar-day']"
+        >
           {{ day }}
         </div>
       </div>
@@ -579,8 +590,8 @@ onMounted(() => {
             styles['calendar-cell'],
             cell.isOtherMonth ? styles['other-month'] : '',
           ]"
-          @click="dayClicked(cell)"
           :data-testid="`calendar-cell-${cell.year}-${cell.month}-${cell.day}`"
+          @click="dayClicked(cell)"
         >
           <span>{{ cell.day }}</span>
           <div :class="styles['calendar-events']">
@@ -606,12 +617,18 @@ onMounted(() => {
                         : "📋"
                   }}
                 </span>
-                <span :class="styles['event-time']" data-testid="event-time">
+                <span
+                  :class="styles['event-time']"
+                  data-testid="event-time"
+                >
                   {{ event.startTime
                   }}<span v-if="event.endTime">-{{ event.endTime }}</span>
                 </span>
               </div>
-              <div :class="styles['event-text']" data-testid="event-text">
+              <div
+                :class="styles['event-text']"
+                data-testid="event-text"
+              >
                 {{
                   event.type === "Cita"
                     ? event.text.replace("Cita: ", "")
@@ -624,8 +641,8 @@ onMounted(() => {
             <div
               v-if="getLimitedEventsForDay(cell).remainingCount > 0"
               :class="styles['more-events']"
-              @click.stop="dayClicked(cell)"
               data-testid="more-events-indicator"
+              @click.stop="dayClicked(cell)"
             >
               +{{ getLimitedEventsForDay(cell).remainingCount }} más
             </div>
@@ -654,7 +671,10 @@ onMounted(() => {
           :data-testid="`agenda-event-${i}`"
         >
           <template v-if="editingIndex === i">
-            <div class="edit-fields" data-testid="edit-fields">
+            <div
+              class="edit-fields"
+              data-testid="edit-fields"
+            >
               <input
                 v-model="editingText"
                 placeholder="Texto"
@@ -678,10 +698,16 @@ onMounted(() => {
               />
             </div>
             <div class="edit-buttons-centered">
-              <button @click="saveEdit(i)" data-testid="save-edit-btn">
+              <button
+                data-testid="save-edit-btn"
+                @click="saveEdit(i)"
+              >
                 Guardar
               </button>
-              <button @click="cancelEdit" data-testid="cancel-edit-btn">
+              <button
+                data-testid="cancel-edit-btn"
+                @click="cancelEdit"
+              >
                 Cancelar
               </button>
             </div>
@@ -704,25 +730,25 @@ onMounted(() => {
               <!-- Botones diferentes según el tipo de evento -->
               <template v-if="event.type === 'Cita'">
                 <button
-                  @click="openAppointmentEdit(event)"
                   :class="styles['edit-btn']"
                   data-testid="edit-appointment-btn"
+                  @click="openAppointmentEdit(event)"
                 >
                   ✏️ Editar Cita
                 </button>
               </template>
               <template v-else>
                 <button
-                  @click="startEdit(i, event)"
                   :class="styles['edit-btn']"
                   data-testid="edit-event-btn"
+                  @click="startEdit(i, event)"
                 >
                   Editar
                 </button>
                 <button
-                  @click="deleteEvent(i)"
                   :class="styles['delete-btn']"
                   data-testid="delete-event-btn"
+                  @click="deleteEvent(i)"
                 >
                   🗑️
                 </button>
@@ -738,12 +764,15 @@ onMounted(() => {
         </li>
       </ul>
 
-      <div :class="styles['agenda-forms']" data-testid="agenda-forms">
+      <div
+        :class="styles['agenda-forms']"
+        data-testid="agenda-forms"
+      >
         <!-- Pacientes fila -->
         <form
-          @submit.prevent="addPatientEvent"
           :class="styles['agenda-form']"
           data-testid="add-patient-form"
+          @submit.prevent="addPatientEvent"
         >
           <input
             v-model="selectedPatient"
@@ -770,16 +799,19 @@ onMounted(() => {
             class="color-input"
             data-testid="patient-color"
           />
-          <button type="submit" data-testid="add-patient-btn">
+          <button
+            type="submit"
+            data-testid="add-patient-btn"
+          >
             Añadir paciente
           </button>
         </form>
 
         <!-- Actividad fila -->
         <form
-          @submit.prevent="addActivityEvent"
           :class="styles['agenda-form']"
           data-testid="add-activity-form"
+          @submit.prevent="addActivityEvent"
         >
           <input
             v-model="activityText"
@@ -806,7 +838,10 @@ onMounted(() => {
             class="color-input"
             data-testid="activity-color"
           />
-          <button type="submit" data-testid="add-activity-btn">
+          <button
+            type="submit"
+            data-testid="add-activity-btn"
+          >
             Añadir actividad
           </button>
         </form>
@@ -817,20 +852,20 @@ onMounted(() => {
     <div
       v-if="showEditModal"
       :class="styles['modal-overlay']"
-      @click="closeEditModal"
       data-testid="edit-modal-overlay"
+      @click="closeEditModal"
     >
       <div
         :class="styles['modal-content']"
-        @click.stop
         data-testid="edit-modal-content"
+        @click.stop
       >
         <div :class="styles['modal-header']">
           <h3>Editar Cita Médica</h3>
           <button
-            @click="closeEditModal"
             :class="styles['close-btn']"
             data-testid="close-modal-btn"
+            @click="closeEditModal"
           >
             &times;
           </button>
@@ -838,8 +873,8 @@ onMounted(() => {
 
         <div :class="styles['modal-body']">
           <form
-            @submit.prevent="saveAppointment"
             data-testid="edit-appointment-form"
+            @submit.prevent="saveAppointment"
           >
             <!-- Selector de paciente mejorado -->
             <div :class="styles['form-group']">
@@ -847,19 +882,19 @@ onMounted(() => {
               <div :class="styles['patient-search']">
                 <input
                   v-model="searchPatient"
-                  @input="filterPatients"
-                  @focus="onSearchFocus"
-                  @blur="onSearchBlur"
                   placeholder="Escriba para buscar paciente..."
                   :class="styles['search-input']"
                   data-testid="patient-search-input"
+                  @input="filterPatients"
+                  @focus="onSearchFocus"
+                  @blur="onSearchBlur"
                 />
                 <div
                   v-if="
                     showPatientDropdown &&
-                    searchPatient &&
-                    searchPatient.length > 2 &&
-                    filteredPatients.length > 0
+                      searchPatient &&
+                      searchPatient.length > 2 &&
+                      filteredPatients.length > 0
                   "
                   :class="styles['patient-dropdown']"
                   data-testid="patient-dropdown"
@@ -867,9 +902,9 @@ onMounted(() => {
                   <div
                     v-for="patient in filteredPatients.slice(0, 5)"
                     :key="patient.id"
-                    @mousedown="selectPatient(patient)"
                     :class="styles['patient-option']"
                     :data-testid="`patient-option-${patient.id}`"
+                    @mousedown="selectPatient(patient)"
                   >
                     <strong>{{ patient.name }}</strong>
                     <span>{{ patient.email }}</span>
@@ -931,17 +966,17 @@ onMounted(() => {
               </button>
               <button
                 type="button"
-                @click="deleteAppointment"
                 :class="styles['delete-btn']"
                 data-testid="delete-appointment-btn"
+                @click="deleteAppointment"
               >
                 🗑️ Eliminar Cita
               </button>
               <button
                 type="button"
-                @click="closeEditModal"
                 :class="styles['cancel-btn']"
                 data-testid="cancel-modal-btn"
+                @click="closeEditModal"
               >
                 Cancelar
               </button>

--- a/frontend-app/src/components/dashboardComponents/TodayPatients.vue
+++ b/frontend-app/src/components/dashboardComponents/TodayPatients.vue
@@ -4,15 +4,24 @@
       Pacientes para hoy — {{ todayFormatted }}
     </h1>
 
-    <div v-if="isLoadingAppointmentsToday" class="text-center py-6">
-      <basic-spinner-loading color="#489FB5" class="mx-auto" />
+    <div
+      v-if="isLoadingAppointmentsToday"
+      class="text-center py-6"
+    >
+      <basic-spinner-loading
+        color="#489FB5"
+        class="mx-auto"
+      />
     </div>
 
     <div v-else>
-      <transition-group name="fade" tag="div">
+      <transition-group
+        name="fade"
+        tag="div"
+      >
         <div
-          v-if="appointmentsToday.length > 0"
           v-for="appointment in appointmentsToday"
+          v-if="appointmentsToday.length > 0"
           :key="appointment.id"
           class="flex items-stretch h-32 rounded-xl overflow-hidden my-4"
         >
@@ -42,8 +51,8 @@
                 'flex items-center justify-center h-full w-1/4 ml-4 shadow-md rounded-xl text-white font-bold text-xl capitalize',
                 statusClass(appointment.status),
               ]"
-              @click="changueStatus(appointment)"
               style="cursor: pointer"
+              @click="changueStatus(appointment)"
             >
               {{ appointment.status }}
             </div>
@@ -58,11 +67,10 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from "vue";
+import { computed, onMounted } from "vue";
 import { storeToRefs } from "pinia";
 import { usePatientsStore } from "../../stores/patientsStore";
 import BasicSpinnerLoading from "../forms/BasicSpinnerLoading.vue";
-import Panel from "@components/forms/Panel.vue";
 
 // Pinia
 const patientsStore = usePatientsStore();

--- a/frontend-app/src/components/dashboardComponents/TodayPatients.vue
+++ b/frontend-app/src/components/dashboardComponents/TodayPatients.vue
@@ -4,64 +4,57 @@
       Pacientes para hoy — {{ todayFormatted }}
     </h1>
 
-    <div
-      v-if="isLoadingAppointmentsToday"
-      class="text-center py-6"
-    >
-      <basic-spinner-loading
-        color="#489FB5"
-        class="mx-auto"
-      />
+    <div v-if="isLoadingAppointmentsToday" class="text-center py-6">
+      <basic-spinner-loading color="#489FB5" class="mx-auto" />
     </div>
 
     <div v-else>
-      <transition-group
-        name="fade"
-        tag="div"
-      >
-        <div
-          v-for="appointment in appointmentsToday"
-          v-if="appointmentsToday.length > 0"
-          :key="appointment.id"
-          class="flex items-stretch h-32 rounded-xl overflow-hidden my-4"
-        >
-          <!-- Info del paciente y cita -->
-          <div class="mb-2 flex w-full">
-            <div
-              class="flex items-center bg-white shadow-md rounded-xl w-3/4 p-4 flex-1"
-            >
-              <div class="flex-1">
-                <h2 class="text-3xl font-bold text-gray-800">
-                  {{ appointment.patientName }}
-                </h2>
-                <p class="text-gray-600">
-                  <span class="font-semibold">Médico:</span>
-                  {{ appointment.doctorName }}
-                </p>
-                <p class="text-gray-500 text-sm">
-                  <span class="font-semibold">Fecha y Hora:</span>
-                  {{ formatDateTime(appointment.date) }}
-                </p>
+      <!-- ✅ v-if en wrapper, NO junto con v-for -->
+      <div v-if="appointmentsToday.length > 0">
+        <transition-group name="fade" tag="div">
+          <div
+            v-for="appointment in appointmentsToday"
+            :key="appointment.id"
+            class="flex items-stretch h-32 rounded-xl overflow-hidden my-4"
+          >
+            <!-- Info del paciente y cita -->
+            <div class="mb-2 flex w-full">
+              <div class="flex items-center bg-white shadow-md rounded-xl w-3/4 p-4 flex-1">
+                <div class="flex-1">
+                  <h2 class="text-3xl font-bold text-gray-800">
+                    {{ appointment.patientName }}
+                  </h2>
+                  <p class="text-gray-600">
+                    <span class="font-semibold">Médico:</span>
+                    {{ appointment.doctorName }}
+                  </p>
+                  <p class="text-gray-500 text-sm">
+                    <span class="font-semibold">Fecha y Hora:</span>
+                    {{ formatDateTime(appointment.date) }}
+                  </p>
+                </div>
+              </div>
+
+              <!-- Botón de estado -->
+              <div
+                :class="[
+                  'flex items-center justify-center h-full w-1/4 ml-4 shadow-md rounded-xl text-white font-bold text-xl capitalize',
+                  statusClass(appointment.status),
+                ]"
+                style="cursor: pointer"
+                @click="changueStatus(appointment)"
+              >
+                {{ appointment.status }}
               </div>
             </div>
-
-            <!-- Botón de estado -->
-            <div
-              :class="[
-                'flex items-center justify-center h-full w-1/4 ml-4 shadow-md rounded-xl text-white font-bold text-xl capitalize',
-                statusClass(appointment.status),
-              ]"
-              style="cursor: pointer"
-              @click="changueStatus(appointment)"
-            >
-              {{ appointment.status }}
-            </div>
           </div>
-        </div>
-        <div v-else>
-          {{ $t("dashboard.no-patients-for-today") }}
-        </div>
-      </transition-group>
+        </transition-group>
+      </div>
+
+      <!-- Mensaje vacío -->
+      <div v-else>
+        {{ $t("dashboard.no-patients-for-today") }}
+      </div>
     </div>
   </div>
 </template>
@@ -72,16 +65,13 @@ import { storeToRefs } from "pinia";
 import { usePatientsStore } from "../../stores/patientsStore";
 import BasicSpinnerLoading from "../forms/BasicSpinnerLoading.vue";
 
-// Pinia
 const patientsStore = usePatientsStore();
-const { appointmentsToday, isLoadingAppointmentsToday } =
-  storeToRefs(patientsStore);
+const { appointmentsToday, isLoadingAppointmentsToday } = storeToRefs(patientsStore);
 
 onMounted(() => {
   patientsStore.fetchAppointmentsToday();
 });
 
-// Fecha de hoy formateada
 const todayFormatted = computed(() =>
   new Date().toLocaleDateString("es-GT", {
     day: "numeric",
@@ -90,48 +80,27 @@ const todayFormatted = computed(() =>
   }),
 );
 
-// --------------------------------------------------
-// Un único array con toda la info de cada estado:
-// - `key` es el valor lowercase en UI
-// - `label` es el string exacto para el enum de Postgres
-// - `class` la clase de Tailwind/CSS que quieres aplicar
-// --------------------------------------------------
 const statuses = [
-  {
-    key: "pendiente",
-    label: "Pendiente",
-    class: "bg-[#F4A261] text-yellow-900",
-  },
-  { key: "confirmado", label: "Confirmado", class: "bg-blue-500" },
-  { key: "completado", label: "Completado", class: "bg-[#48C9B0]" },
-  { key: "cancelado", label: "Cancelado", class: "bg-red-500" },
-  { key: "espera", label: "Espera", class: "bg-[#F39C12]" },
+  { key: "pendiente",   label: "Pendiente",   class: "bg-[#F4A261] text-yellow-900" },
+  { key: "confirmado",  label: "Confirmado",  class: "bg-blue-500" },
+  { key: "completado",  label: "Completado",  class: "bg-[#48C9B0]" },
+  { key: "cancelado",   label: "Cancelado",   class: "bg-red-500" },
+  { key: "espera",      label: "Espera",      class: "bg-[#F39C12]" },
 ];
 
-// Para buscar rápido un estado por su key
 const statusMap = Object.fromEntries(statuses.map((s) => [s.key, s]));
 
 async function changueStatus(appointment) {
-  // 1) Calcula índice y nextKey
   const currKey = appointment.status.toLowerCase();
   const idx = statuses.findIndex((s) => s.key === currKey);
   const next = statuses[(idx + 1) % statuses.length];
 
-  // 2) Cambio optimista
   appointment.status = next.key;
 
-  // 3) PATCH contra el backend
-  const ok = await patientsStore.updateAppointmentStatus(
-    appointment.id,
-    next.label,
-  );
-  if (!ok) {
-    // si fallo, revertimos
-    appointment.status = currKey;
-  }
+  const ok = await patientsStore.updateAppointmentStatus(appointment.id, next.label);
+  if (!ok) appointment.status = currKey;
 }
 
-// Ahora simplemente buscamos en statusMap para aplicar clases
 function statusClass(status) {
   const key = status?.toLowerCase();
   return statusMap[key]?.class || "bg-gray-400";

--- a/frontend-app/src/components/forms/ActionButtonOutlinedIcon.vue
+++ b/frontend-app/src/components/forms/ActionButtonOutlinedIcon.vue
@@ -1,10 +1,16 @@
 <template>
   <form @submit.prevent>
     <button :class="[buttonStyles]">
-      <p v-if="props.title !== 'general.empty'" class="mr-2">
+      <p
+        v-if="props.title !== 'general.empty'"
+        class="mr-2"
+      >
         {{ $t(props.title) }}
       </p>
-      <component :is="icons[icon]" :class="[props.color, props.size]" />
+      <component
+        :is="icons[icon]"
+        :class="[props.color, props.size]"
+      />
     </button>
   </form>
 </template>
@@ -42,7 +48,10 @@ import {
   ChartBarSquareIcon,
 } from "@heroicons/vue/24/outline";
 const props = defineProps({
-  icon: String,
+  icon: {
+    type: String,
+    default: "PlusIcon",
+  },
   color: {
     type: String,
     default: "text-primary-color",

--- a/frontend-app/src/components/forms/ActionButtonSolidIcon.vue
+++ b/frontend-app/src/components/forms/ActionButtonSolidIcon.vue
@@ -1,10 +1,16 @@
 <template>
   <form @submit.prevent>
     <button :class="[buttonStyles]">
-      <p v-if="props.title !== 'general.empty'" class="mr-2">
+      <p
+        v-if="props.title !== 'general.empty'"
+        class="mr-2"
+      >
         {{ $t(props.title) }}
       </p>
-      <component :is="icons[icon]" :class="[props.color, props.size]" />
+      <component
+        :is="icons[icon]"
+        :class="[props.color, props.size]"
+      />
     </button>
   </form>
 </template>
@@ -42,7 +48,10 @@ import {
   ChartBarSquareIcon,
 } from "@heroicons/vue/24/solid";
 const props = defineProps({
-  icon: String,
+  icon: {
+    type: String,
+    default: "PlusIcon",
+  },
   color: {
     type: String,
     default: "text-primary-color",

--- a/frontend-app/src/components/forms/AppPanel.vue
+++ b/frontend-app/src/components/forms/AppPanel.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="overflow-hidden rounded-lg bg-white shadow-md">
     <div class="px-4 py-5 sm:p-6">
-      <slot />
+      <slot></slot>
     </div>
   </div>
 </template>

--- a/frontend-app/src/components/forms/BasicSpinnerLoading.vue
+++ b/frontend-app/src/components/forms/BasicSpinnerLoading.vue
@@ -1,6 +1,6 @@
 <template>
   <svg
-    :style="{ color }"
+    :style="{ color: props.color }"
     class="animate-spin h-5 w-5 text-gray"
     xmlns="http://www.w3.org/2000/svg"
     fill="none"

--- a/frontend-app/src/components/forms/BasicSpinnerLoading.vue
+++ b/frontend-app/src/components/forms/BasicSpinnerLoading.vue
@@ -13,12 +13,12 @@
       r="10"
       stroke="currentColor"
       stroke-width="4"
-    ></circle>
+    />
     <path
       class="opacity-75"
       fill="currentColor"
       d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-    ></path>
+    />
   </svg>
 </template>
 <script setup>

--- a/frontend-app/src/components/forms/ComboBoxAutocompleteInputSearchPatient.vue
+++ b/frontend-app/src/components/forms/ComboBoxAutocompleteInputSearchPatient.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="w-full">
-    <Combobox
-      v-model="selected"
-      @update:model-value="onSelect"
-    >
+    <Combobox v-model="selected" @update:model-value="onSelect">
       <div class="relative">
         <ComboboxInput
           class="w-full border-none py-2 pl-3 pr-10 text-sm leading-5 text-gray-900 focus:ring-0 bg-white placeholder:text-gray-400"
@@ -12,14 +9,10 @@
           @change="query = $event.target.value"
           @focus="query = ''"
         />
-        <ComboboxButton
-          class="absolute inset-y-0 right-0 flex items-center pr-2"
-        >
-          <ChevronUpDownIcon
-            class="h-5 w-5 text-gray-400"
-            aria-hidden="true"
-          />
+        <ComboboxButton class="absolute inset-y-0 right-0 flex items-center pr-2">
+          <ChevronUpDownIcon class="h-5 w-5 text-gray-400" aria-hidden="true" />
         </ComboboxButton>
+
         <TransitionRoot
           leave="transition ease-in duration-100"
           leaveFrom="opacity-100"
@@ -35,11 +28,12 @@
             >
               {{ $t("general.patient-not-found") }}
             </div>
+
             <!-- Opciones de pacientes -->
             <ComboboxOption
               v-for="person in filteredPeople"
               :key="person.id"
-              v-slot="{ selected, active }"
+              v-slot="{ selected: isSelected, active }"
               as="template"
               :value="person"
             >
@@ -52,19 +46,16 @@
               >
                 <span
                   class="block truncate"
-                  :class="{ 'font-medium': selected, 'font-normal': !selected }"
+                  :class="{ 'font-medium': isSelected, 'font-normal': !isSelected }"
                 >
                   {{ person.name }} {{ person.lastName }} ({{ person.gender }})
                 </span>
                 <span
-                  v-if="selected"
+                  v-if="isSelected"
                   class="absolute inset-y-0 left-0 flex items-center pl-3"
                   :class="{ 'text-white': active, 'text-teal-600': !active }"
                 >
-                  <CheckIcon
-                    class="h-5 w-5"
-                    aria-hidden="true"
-                  />
+                  <CheckIcon class="h-5 w-5" aria-hidden="true" />
                 </span>
               </li>
             </ComboboxOption>
@@ -87,66 +78,55 @@ import {
 } from "@headlessui/vue";
 import { CheckIcon, ChevronUpDownIcon } from "@heroicons/vue/20/solid";
 
-// Definición de props y eventos
 const emit = defineEmits(["update:currentSelected"]);
 const props = defineProps({
-  data: {
-    type: Array,
-    default: () => [],
-  },
-  currentSelected: {
-    type: Number,
-    default: undefined,
-  },
-  placeholder: {
-    type: String,
-    default: "",
-  },
-  isRequired: {
-    type: Boolean,
-    default: false,
-  },
+  data: { type: Array, default: () => [] },
+  currentSelected: { type: Number, default: undefined },
+  placeholder: { type: String, default: "" },
+  isRequired: { type: Boolean, default: false },
 });
 
-// Lista de personas (pacientes) a mostrar
 const people = computed(() =>
-  Array.isArray(props.data) && props.data.length > 0 ? props.data : [],
+  Array.isArray(props.data) && props.data.length > 0 ? props.data : []
 );
 
-// Paciente seleccionado actualmente
 const selected = ref(null);
-// Texto de búsqueda actual
 const query = ref("");
 
-// Sincroniza el valor seleccionado externo con el interno
+// Sincroniza selección externa → interna
 watch(
   () => props.currentSelected,
   (newVal) => {
     selected.value = people.value.find((p) => p.id === newVal) || null;
   },
+  { immediate: true }
 );
 
-// Cuando se selecciona un paciente, emite el id al padre
+// Emitir id al seleccionar
 function onSelect(newVal) {
   selected.value = newVal;
   emit("update:currentSelected", newVal?.id);
 }
 
-// Muestra el nombre del paciente seleccionado en el input, o el placeholder si no hay selección
+// Texto mostrado en el input
 function displayText(person) {
   if (!person || query.value !== "") return "";
-  return `${person.name} ${person.lastName} (${person.gender})`;
+  const name = person?.name ?? "";
+  const last = person?.lastName ?? "";
+  const gender = person?.gender ?? "";
+  return `${name} ${last} (${gender})`;
 }
 
-// Filtra la lista de pacientes según el texto de búsqueda
-const filteredPeople = computed(() =>
-  query.value === ""
-    ? people.value
-    : people.value.filter((person) =>
-        (`${person.name} ${person.lastName}` ?? "")
-          .toLowerCase()
-          .replace(/\s+/g, "")
-          .includes(query.value.toLowerCase().replace(/\s+/g, "")),
-      ),
-);
+// Filtro por query (sin `??` inválido)
+const filteredPeople = computed(() => {
+  const q = query.value.toLowerCase().replace(/\s+/g, "");
+  if (!q) return people.value;
+
+  return people.value.filter((person) => {
+    const name = (person?.name ?? "").toLowerCase();
+    const last = (person?.lastName ?? "").toLowerCase();
+    const merged = (name + " " + last).replace(/\s+/g, "");
+    return merged.includes(q);
+  });
+});
 </script>

--- a/frontend-app/src/components/forms/ComboBoxAutocompleteInputSearchPatient.vue
+++ b/frontend-app/src/components/forms/ComboBoxAutocompleteInputSearchPatient.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="w-full">
-    <Combobox v-model="selected" @update:modelValue="onSelect">
+    <Combobox
+      v-model="selected"
+      @update:model-value="onSelect"
+    >
       <div class="relative">
         <ComboboxInput
           class="w-full border-none py-2 pl-3 pr-10 text-sm leading-5 text-gray-900 focus:ring-0 bg-white placeholder:text-gray-400"
@@ -12,7 +15,10 @@
         <ComboboxButton
           class="absolute inset-y-0 right-0 flex items-center pr-2"
         >
-          <ChevronUpDownIcon class="h-5 w-5 text-gray-400" aria-hidden="true" />
+          <ChevronUpDownIcon
+            class="h-5 w-5 text-gray-400"
+            aria-hidden="true"
+          />
         </ComboboxButton>
         <TransitionRoot
           leave="transition ease-in duration-100"
@@ -23,7 +29,6 @@
           <ComboboxOptions
             class="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-none sm:text-sm"
           >
-            <!-- Mensaje si no se encuentra ningún paciente -->
             <div
               v-if="filteredPeople.length === 0 && query !== ''"
               class="relative cursor-default select-none px-4 py-2 text-gray-700"
@@ -33,10 +38,10 @@
             <!-- Opciones de pacientes -->
             <ComboboxOption
               v-for="person in filteredPeople"
-              as="template"
               :key="person.id"
-              :value="person"
               v-slot="{ selected, active }"
+              as="template"
+              :value="person"
             >
               <li
                 class="relative cursor-default select-none py-2 pl-10 pr-4"
@@ -56,7 +61,10 @@
                   class="absolute inset-y-0 left-0 flex items-center pl-3"
                   :class="{ 'text-white': active, 'text-teal-600': !active }"
                 >
-                  <CheckIcon class="h-5 w-5" aria-hidden="true" />
+                  <CheckIcon
+                    class="h-5 w-5"
+                    aria-hidden="true"
+                  />
                 </span>
               </li>
             </ComboboxOption>
@@ -135,7 +143,7 @@ const filteredPeople = computed(() =>
   query.value === ""
     ? people.value
     : people.value.filter((person) =>
-        (`${person.name} ${person.lastName}` || "")
+        (`${person.name} ${person.lastName}` ?? "")
           .toLowerCase()
           .replace(/\s+/g, "")
           .includes(query.value.toLowerCase().replace(/\s+/g, "")),

--- a/frontend-app/src/components/forms/ComboboxesInput.vue
+++ b/frontend-app/src/components/forms/ComboboxesInput.vue
@@ -36,8 +36,6 @@ watch(
   () => model.value,
   (newIds) => {
     if (!Array.isArray(newIds)) return;
-
-    const knownIds = new Set(props.data.map((i) => i.id));
     selectedItems.value = newIds.map((id) => {
       const item = props.data.find((d) => d.id === id);
       return item ?? { id, name: `ID: ${id}` };
@@ -64,17 +62,21 @@ watch(
     <custom-label
       v-if="title"
       :title="title"
-      :text-class="labelCss"
-      :is-required="isRequired"
+      :textClass="labelCss"
+      :isRequired="isRequired"
     />
-    <Combobox as="div" :multiple="multiple" v-model="selectedItems">
+    <Combobox
+      v-model="selectedItems"
+      as="div"
+      :multiple="multiple"
+    >
       <div class="relative mt-2">
         <ComboboxInput
           class="block w-full rounded-md bg-white py-1.5 pr-12 pl-3 text-base text-gray-900 border border-patient-page-color placeholder:text-gray-400 focus:border-patient-page-color focus:ring-patient-page-color focus:ring-1 focus:outline-none sm:text-sm"
           :placeholder="$t(placeholder)"
+          :displayValue="() => selectedDisplay"
           @change="query = $event.target.value"
           @blur="query = ''"
-          :display-value="() => selectedDisplay"
         />
         <ComboboxButton
           class="absolute inset-y-0 right-0 flex items-center rounded-r-md px-2 focus:outline-hidden"
@@ -89,9 +91,9 @@ watch(
           <ComboboxOption
             v-for="item in fullData"
             :key="item.id"
+            v-slot="{ active, selected }"
             :value="item"
             as="template"
-            v-slot="{ active, selected }"
           >
             <li
               :class="[

--- a/frontend-app/src/components/forms/ComboboxesInput.vue
+++ b/frontend-app/src/components/forms/ComboboxesInput.vue
@@ -19,6 +19,9 @@ const props = defineProps({
   isRequired: { type: Boolean, default: false },
 });
 
+// Declarar los eventos que el componente puede emitir (incluye "close")
+const emit = defineEmits(["close"]);
+
 const model = defineModel("currentSelected"); // Esto será un array de IDs
 const selectedItems = ref([]);
 const query = ref("");

--- a/frontend-app/src/components/forms/ComboboxesInput.vue
+++ b/frontend-app/src/components/forms/ComboboxesInput.vue
@@ -2,11 +2,7 @@
 import { ref, computed, watch } from "vue";
 import { CheckIcon, ChevronDownIcon } from "@heroicons/vue/20/solid";
 import {
-  Combobox,
-  ComboboxButton,
-  ComboboxInput,
-  ComboboxOption,
-  ComboboxOptions,
+  Combobox, ComboboxButton, ComboboxInput, ComboboxOption, ComboboxOptions,
 } from "@headlessui/vue";
 import CustomLabel from "@/components/forms/CustomLabel.vue";
 
@@ -19,26 +15,25 @@ const props = defineProps({
   isRequired: { type: Boolean, default: false },
 });
 
-// Declarar los eventos que el componente puede emitir (incluye "close")
-const emit = defineEmits(["close"]);
+// ❌ const emit = defineEmits(["close"]); // no lo usas → elimínalo
 
-const model = defineModel("currentSelected"); // Esto será un array de IDs
+// ✅ Declara tipo del modelo
+const model = defineModel("currentSelected", {
+  type: [Array, Number, null],
+  default: () => [],
+});
+
 const selectedItems = ref([]);
 const query = ref("");
 
-// Mostrar nombres
-const selectedDisplay = computed(() => {
-  return selectedItems.value.map((i) => i.name).join(", ");
-});
-
-// Para mostrar los elementos visibles, usar `data` directamente
+const selectedDisplay = computed(() => selectedItems.value.map((i) => i.name).join(", "));
 const fullData = computed(() => props.data);
 
-// Convertir el modelo (array de IDs) en objetos (algunos conocidos, otros no)
+// Sync modelo (ids) → objetos
 watch(
   () => model.value,
   (newIds) => {
-    if (!Array.isArray(newIds)) return;
+    if (!Array.isArray(newIds)) return; // si estás en modo single, lo ignoras
     selectedItems.value = newIds.map((id) => {
       const item = props.data.find((d) => d.id === id);
       return item ?? { id, name: `ID: ${id}` };
@@ -47,7 +42,7 @@ watch(
   { immediate: true },
 );
 
-// Convertir objetos seleccionados en array de IDs
+// Objetos seleccionados → modelo (ids)
 watch(
   selectedItems,
   (items) => {

--- a/frontend-app/src/components/forms/CustomLabel.vue
+++ b/frontend-app/src/components/forms/CustomLabel.vue
@@ -1,17 +1,27 @@
 <template>
   <div class="flex items-center justify-start">
-    <div v-if="isRequired" class="text-red-600">*</div>
+    <div
+      v-if="isRequired"
+      class="text-red-600"
+    >
+      *
+    </div>
     <label
       :for="props.name"
       :class="[props.textClass, 'block leading-6 truncate', props.textSize]"
-      >{{ $t(props.title) }}</label
-    >
+    >{{ $t(props.title) }}</label>
   </div>
 </template>
 <script setup>
 const props = defineProps({
-  name: String,
-  title: String,
+  name: {
+    type: String,
+    default: "",
+  },
+  title: {
+    type: String,
+    default: "",
+  },
   textClass: {
     type: String,
     default: "text-gray-600",

--- a/frontend-app/src/components/forms/DragDropFileInput.vue
+++ b/frontend-app/src/components/forms/DragDropFileInput.vue
@@ -7,12 +7,12 @@
   >
     <div :disabled="isDragging">
       <input
+        id="filePdf_input"
         ref="filePdf"
         class="hidden"
-        @change="handleFilePdf"
-        id="filePdf_input"
         type="file"
         :accept="aceptAll ? true : 'application/pdf'"
+        @change="handleFilePdf"
       />
       <div class="flex items-center m-4">
         <action-button-outlined-icon
@@ -22,7 +22,11 @@
           color="text-patient-page-color"
           @click="triggerFilePdf"
         />
-        <a @click="triggerFilePdf" class="ml-2" role="button">{{
+        <a
+          class="ml-2"
+          role="button"
+          @click="triggerFilePdf"
+        >{{
           $t(title)
         }}</a>
         <action-button-outlined-icon
@@ -33,16 +37,15 @@
         <action-button-outlined-icon
           v-if="filePdfUploaded"
           icon="TrashIcon"
-          @click="deletePdf"
           size="h-6 w-6 mr-1"
           color="text-red-500"
+          @click="deletePdf"
         />
       </div>
     </div>
   </div>
 </template>
 <script setup>
-import ActionButtonSolidIcon from "@components/forms/ActionButtonSolidIcon.vue";
 import ActionButtonOutlinedIcon from "@components/forms/ActionButtonOutlinedIcon.vue";
 import { ref } from "vue";
 
@@ -60,7 +63,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  currentSelected: {},
+  currentSelected: {
+    type: [String, Object, File],
+    default: null,
+  },
 });
 
 const filePdf = ref(null);

--- a/frontend-app/src/components/forms/DragDropFileInput.vue
+++ b/frontend-app/src/components/forms/DragDropFileInput.vue
@@ -54,6 +54,7 @@ const props = defineProps({
   data: {
     type: [String, File, Object],
     required: false,
+    default: null,
   },
   title: {
     type: String,

--- a/frontend-app/src/components/forms/GeneralDialogModal.vue
+++ b/frontend-app/src/components/forms/GeneralDialogModal.vue
@@ -1,15 +1,23 @@
 <template>
   <div>
-    <transition-root appear :show="props.isOpen" as="template">
-      <Dialog as="div" @close="closeModal" class="relative z-50">
+    <transition-root
+      appear
+      :show="props.isOpen"
+      as="template"
+    >
+      <Dialog
+        as="div"
+        class="relative z-50"
+        @close="closeModal"
+      >
         <transition-child
           as="template"
           enter="duration-300 ease-out"
-          enter-from="opacity-0"
-          enter-to="opacity-100"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
           leave="duration-200 ease-in"
-          leave-from="opacity-100"
-          leave-to="opacity-0"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
         >
           <div class="fixed inset-0 bg-black/25 pointer-events-none"></div>
         </transition-child>
@@ -21,11 +29,11 @@
             <transition-child
               as="template"
               enter="duration-300 ease-out"
-              enter-from="opacity-0 scale-95"
-              enter-to="opacity-100 scale-100"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
               leave="duration-200 ease-in"
-              leave-from="opacity-100 scale-100"
-              leave-to="opacity-0 scale-95"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
             >
               <dialog-panel
                 :class="[
@@ -34,9 +42,11 @@
                 ]"
               >
                 <dialog-title class="mb-4">
-                  <slot name="title"> </slot>
+                  <slot name="title">
+                  </slot>
                 </dialog-title>
-                <slot name="body"> </slot>
+                <slot name="body">
+                </slot>
                 <div class="mt-2 flex justify-end">
                   <primary-button
                     v-if="cancelButton === false"
@@ -49,7 +59,8 @@
                       {{ $t("general.cancel") }}
                     </p>
                   </primary-button>
-                  <slot name="buttons"> </slot>
+                  <slot name="buttons">
+                  </slot>
                 </div>
               </dialog-panel>
             </transition-child>
@@ -67,8 +78,7 @@ import {
   TransitionChild,
   Dialog,
   DialogTitle,
-  DialogPanel,
-  Portal,
+  DialogPanel
 } from "@headlessui/vue";
 
 const emit = defineEmits(["closeModal"]);

--- a/frontend-app/src/components/forms/GeneralIFrame.vue
+++ b/frontend-app/src/components/forms/GeneralIFrame.vue
@@ -11,14 +11,16 @@
     </div>
     <div class="block sm:hidden mt-4">
       <primary-button @click="downloadPdf">
-        <div class="uppercase">{{ $t("general.download-pdf") }}</div>
+        <div class="uppercase">
+          {{ $t("general.download-pdf") }}
+        </div>
       </primary-button>
     </div>
   </div>
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from "vue";
+import { computed, onMounted, watch } from "vue";
 import { useBlobAdapter } from "@/composables/useBlobAdapter";
 import PrimaryButton from "@components/forms/PrimaryButton.vue";
 

--- a/frontend-app/src/components/forms/NotificationAlert.vue
+++ b/frontend-app/src/components/forms/NotificationAlert.vue
@@ -8,12 +8,12 @@
         <transition
           v-for="(n, index) in notifications"
           :key="index"
-          enter-active-class="transform ease-out duration-300 transition"
-          enter-from-class="translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2"
-          enter-to-class="translate-y-0 opacity-100 sm:translate-x-0"
-          leave-active-class="transition ease-in duration-100"
-          leave-from-class="opacity-100"
-          leave-to-class="opacity-0"
+          enterActiveClass="transform ease-out duration-300 transition"
+          enterFromClass="translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2"
+          enterToClass="translate-y-0 opacity-100 sm:translate-x-0"
+          leaveActiveClass="transition ease-in duration-100"
+          leaveFromClass="opacity-100"
+          leaveToClass="opacity-0"
         >
           <div
             v-if="n.visible"
@@ -49,8 +49,8 @@
                 </div>
                 <button
                   type="button"
-                  @click="notificationStore.hideNotification(n.id)"
                   class="ml-4 shrink-0 text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  @click="notificationStore.hideNotification(n.id)"
                 >
                   <span class="sr-only">Close</span>
                   <XMarkIcon

--- a/frontend-app/src/components/forms/PrimaryButton.vue
+++ b/frontend-app/src/components/forms/PrimaryButton.vue
@@ -9,7 +9,7 @@
       ]"
       :disabled="props.isDisabled"
     >
-      <slot />
+      <slot></slot>
     </button>
   </div>
 </template>

--- a/frontend-app/src/components/forms/RadioGroup.vue
+++ b/frontend-app/src/components/forms/RadioGroup.vue
@@ -38,6 +38,7 @@
 </template>
 
 <script setup>
+import { computed } from "vue";
 import CustomLabel from "@/components/forms/CustomLabel.vue";
 const props = defineProps({
   title: {
@@ -69,5 +70,13 @@ const props = defineProps({
     default: "general.empty",
   },
 });
-const selected = defineModel("currentSelected");
+
+// declarar el emit para el v-model ("update:currentSelected")
+const emit = defineEmits(["update:currentSelected"]);
+
+// sustituir defineModel por un computed con getter/setter
+const selected = computed({
+  get: () => props.currentSelected,
+  set: (val) => emit("update:currentSelected", val),
+});
 </script>

--- a/frontend-app/src/components/forms/RadioGroup.vue
+++ b/frontend-app/src/components/forms/RadioGroup.vue
@@ -4,8 +4,8 @@
       v-if="title"
       :title="title"
       :name="name"
-      :text-class="labelCss"
-      :is-required="isRequired"
+      :textClass="labelCss"
+      :isRequired="isRequired"
     />
     <fieldset>
       <div
@@ -19,9 +19,9 @@
           <div class="flex h-6 items-center">
             <input
               :id="d.id"
+              v-model="selected"
               :name="name"
               type="radio"
-              v-model="selected"
               :value="d.id"
               class="relative size-4 appearance-none rounded-full border border-gray-300 bg-white before:absolute before:inset-1 before:rounded-full before:bg-white not-checked:before:hidden checked:border-patient-page-color checked:bg-patient-page-color focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-patient-page-color disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 forced-colors:appearance-auto forced-colors:before:hidden"
             />
@@ -39,7 +39,6 @@
 
 <script setup>
 import CustomLabel from "@/components/forms/CustomLabel.vue";
-import { computed } from "vue";
 const props = defineProps({
   title: {
     type: String,

--- a/frontend-app/src/components/forms/SpinnerLoading.vue
+++ b/frontend-app/src/components/forms/SpinnerLoading.vue
@@ -12,11 +12,11 @@
       r="10"
       stroke="currentColor"
       stroke-width="4"
-    ></circle>
+    />
     <path
       class="opacity-75"
       fill="currentColor"
       d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-    ></path>
+    />
   </svg>
 </template>

--- a/frontend-app/src/components/forms/TextInput.vue
+++ b/frontend-app/src/components/forms/TextInput.vue
@@ -5,24 +5,24 @@
       v-if="title"
       :title="title"
       :name="name"
-      :text-class="labelCss"
+      :textClass="labelCss"
     />
-    <div :class="{ 'mt-2': title && title !== 'general.empty' }" />
+    <div :class="{ 'mt-2': title && title !== 'general.empty' }"></div>
     <!-- Input -->
     <div class="relative w-full">
       <input
         :id="name"
+        v-model="value"
         :name="name"
         :type="type"
         :placeholder="$t(inputPlaceholder)"
-        v-model="value"
-        @blur="handleBlur"
         :required="required"
         :class="[
           'block w-full rounded-md border-0 py-1.5 text-gray-900 shadow ring-1 ring-inset sm:text-sm sm:leading-6 px-2',
           ringColorClass,
           focusOutlineClass,
         ]"
+        @blur="handleBlur"
       />
     </div>
   </div>
@@ -68,7 +68,7 @@ const props = defineProps({
   },
 });
 
-const { value, errorMessage, handleChange, handleBlur } = useField(props.name);
+const { value, handleBlur } = useField(props.name);
 
 const ringColorClass = computed(() => {
   switch (props.inputColor) {

--- a/frontend-app/src/components/navigation/NavigationBar.vue
+++ b/frontend-app/src/components/navigation/NavigationBar.vue
@@ -1,8 +1,17 @@
 <template>
-  <ul role="list" class="flex flex-1 flex-col gap-y-7">
+  <ul
+    role="list"
+    class="flex flex-1 flex-col gap-y-7"
+  >
     <li>
-      <ul role="list" class="-mx-2 space-y-1">
-        <li v-for="(item, key) in navigationObject" :key="key">
+      <ul
+        role="list"
+        class="-mx-2 space-y-1"
+      >
+        <li
+          v-for="(item, key) in navigationObject"
+          :key="key"
+        >
           <!-- Item simple -->
           <RouterLink
             v-if="!item.children"
@@ -27,8 +36,14 @@
           <div v-else>
             <!-- botón del disclosure -->
             <!-- ... -->
-            <ul v-show="openIndex === key" class="mt-1 px-2">
-              <li v-for="(subItem, subKey) in item.children" :key="subKey">
+            <ul
+              v-show="openIndex === key"
+              class="mt-1 px-2"
+            >
+              <li
+                v-for="(subItem, subKey) in item.children"
+                :key="subKey"
+              >
                 <RouterLink
                   :to="subItem.to"
                   :data-testid="`nav-${key}-${subKey}`"
@@ -51,12 +66,18 @@
       </ul>
     </li>
     <div class="relative">
-      <div class="absolute inset-0 flex items-center" aria-hidden="true">
-        <div class="w-full border-t border-primary-color-variation-1" />
+      <div
+        class="absolute inset-0 flex items-center"
+        aria-hidden="true"
+      >
+        <div class="w-full border-t border-primary-color-variation-1"></div>
       </div>
     </div>
-    <button @click="logout" class="flex justify-start">
-      <x-circle-icon class="h-6 w-6 shrink-0 text-white"></x-circle-icon>
+    <button
+      class="flex justify-start"
+      @click="logout"
+    >
+      <x-circle-icon class="h-6 w-6 shrink-0 text-white" />
       <span class="text-md ml-2 text-white font-bold">{{
         $t("general.exit")
       }}</span>
@@ -73,7 +94,6 @@ import {
   UserIcon,
   ChartBarIcon,
   CalendarIcon,
-  ChevronRightIcon,
   XCircleIcon,
 } from "@heroicons/vue/24/outline";
 

--- a/frontend-app/src/components/patientsComponents/MedicalRecipePanel.vue
+++ b/frontend-app/src/components/patientsComponents/MedicalRecipePanel.vue
@@ -1,21 +1,18 @@
 <template>
-  <div
-    class="fixed inset-0 z-50 flex items-center justify-center bg-gray-200 bg-opacity-95"
-  >
-    <div
-      class="bg-gray-200 rounded-lg shadow-lg w-full max-w-xl p-8 flex flex-col gap-6"
-    >
+  <div class="fixed inset-0 z-50 flex items-center justify-center bg-gray-200 bg-opacity-95">
+    <div class="bg-gray-200 rounded-lg shadow-lg w-full max-w-xl p-8 flex flex-col gap-6">
       <div class="flex justify-between items-center mb-4">
         <h2 class="text-2xl font-bold">
           {{ $t("patients.consult-detail") }}
         </h2>
         <button
           class="text-gray-500 hover:text-gray-800 text-2xl"
-          @click="$emit('close')"
+          @click="emit('close')"
         >
           &times;
         </button>
       </div>
+
       <div class="grid grid-cols-1 gap-4">
         <div class="bg-blue-100 rounded-lg p-4 shadow">
           <h3 class="text-lg font-semibold mb-2">
@@ -25,10 +22,12 @@
             (Aquí irá la nota de evolución)
           </div>
         </div>
+
         <div class="bg-blue-100 rounded-lg p-4 shadow">
           <h3 class="text-lg font-semibold mb-2">
             {{ $t("patients.medical-recipe") }}
           </h3>
+
           <div v-if="recipe">
             <div class="text-sm text-gray-500 mb-2">
               Fecha: {{ recipe.createdAt }}
@@ -37,10 +36,8 @@
               {{ recipe.prescription }}
             </div>
           </div>
-          <div
-            v-else
-            class="text-gray-400 italic"
-          >
+
+          <div v-else class="text-gray-400 italic">
             {{ $t("patients.no-recipe-selected") }}
           </div>
         </div>
@@ -50,10 +47,9 @@
 </template>
 
 <script setup>
-const props = defineProps({
-  recipe: {
-    type: Object,
-    default: null,
-  },
+const { recipe } = defineProps({
+  recipe: { type: Object, default: null },
 });
+
+const emit = defineEmits(["close"]);
 </script>

--- a/frontend-app/src/components/patientsComponents/MedicalRecipePanel.vue
+++ b/frontend-app/src/components/patientsComponents/MedicalRecipePanel.vue
@@ -6,10 +6,12 @@
       class="bg-gray-200 rounded-lg shadow-lg w-full max-w-xl p-8 flex flex-col gap-6"
     >
       <div class="flex justify-between items-center mb-4">
-        <h2 class="text-2xl font-bold">{{ $t("patients.consult-detail") }}</h2>
+        <h2 class="text-2xl font-bold">
+          {{ $t("patients.consult-detail") }}
+        </h2>
         <button
-          @click="$emit('close')"
           class="text-gray-500 hover:text-gray-800 text-2xl"
+          @click="$emit('close')"
         >
           &times;
         </button>
@@ -31,9 +33,14 @@
             <div class="text-sm text-gray-500 mb-2">
               Fecha: {{ recipe.createdAt }}
             </div>
-            <div class="whitespace-pre-line">{{ recipe.prescription }}</div>
+            <div class="whitespace-pre-line">
+              {{ recipe.prescription }}
+            </div>
           </div>
-          <div v-else class="text-gray-400 italic">
+          <div
+            v-else
+            class="text-gray-400 italic"
+          >
             {{ $t("patients.no-recipe-selected") }}
           </div>
         </div>
@@ -44,6 +51,9 @@
 
 <script setup>
 const props = defineProps({
-  recipe: Object,
+  recipe: {
+    type: Object,
+    default: null,
+  },
 });
 </script>

--- a/frontend-app/src/components/patientsComponents/MedicalRecordDetailsModal.vue
+++ b/frontend-app/src/components/patientsComponents/MedicalRecordDetailsModal.vue
@@ -19,8 +19,8 @@
           </p>
         </div>
         <button
-          @click="$emit('close')"
           class="text-white hover:text-gray-200 text-2xl p-2 rounded-full hover:bg-blue-700 transition-colors"
+          @click="$emit('close')"
         >
           &times;
         </button>
@@ -36,30 +36,28 @@
             </h3>
             <div class="grid grid-cols-2 gap-4">
               <div>
-                <span class="text-sm text-gray-600"
-                  >{{ $t("general.date") }}:</span
-                >
+                <span class="text-sm text-gray-600">{{ $t("general.date") }}:</span>
                 <p class="font-medium">
                   {{ formatRecordDate(record?.createdAt) }}
                 </p>
               </div>
               <div>
-                <span class="text-sm text-gray-600"
-                  >{{ $t("general.status") }}:</span
-                >
-                <p class="font-medium">{{ record?.status || "Completado" }}</p>
+                <span class="text-sm text-gray-600">{{ $t("general.status") }}:</span>
+                <p class="font-medium">
+                  {{ record?.status || "Completado" }}
+                </p>
               </div>
               <div v-if="record?.appointmentType">
-                <span class="text-sm text-gray-600"
-                  >{{ $t("general.appointment-type") }}:</span
-                >
-                <p class="font-medium">{{ record.appointmentType }}</p>
+                <span class="text-sm text-gray-600">{{ $t("general.appointment-type") }}:</span>
+                <p class="font-medium">
+                  {{ record.appointmentType }}
+                </p>
               </div>
               <div v-if="record?.diagnosis">
-                <span class="text-sm text-gray-600"
-                  >{{ $t("general.diagnosis") }}:</span
-                >
-                <p class="font-medium">{{ record.diagnosis }}</p>
+                <span class="text-sm text-gray-600">{{ $t("general.diagnosis") }}:</span>
+                <p class="font-medium">
+                  {{ record.diagnosis }}
+                </p>
               </div>
             </div>
           </div>
@@ -71,8 +69,8 @@
                 {{ $t("patients.evolution-note") }}
               </h3>
               <button
-                @click="editEvolutionNote"
                 class="text-blue-600 hover:text-blue-800 text-sm flex items-center gap-1"
+                @click="editEvolutionNote"
               >
                 <action-button-solid-icon
                   icon="PencilIcon"
@@ -90,7 +88,10 @@
                 {{ record?.medicalRecord?.notes || record?.evolutionNote }}
               </p>
             </div>
-            <div v-else class="text-gray-400 italic py-4">
+            <div
+              v-else
+              class="text-gray-400 italic py-4"
+            >
               {{ $t("patients.no-evolution-note") }}
             </div>
           </div>
@@ -103,8 +104,8 @@
               </h3>
               <button
                 v-if="record?.recipes && record.recipes.length > 0"
-                @click="editFirstRecipe"
                 class="text-green-600 hover:text-green-800 text-sm flex items-center gap-1"
+                @click="editFirstRecipe"
               >
                 <action-button-solid-icon
                   icon="PencilIcon"
@@ -121,9 +122,9 @@
                 class="mb-3 p-3 bg-white rounded border relative"
               >
                 <button
-                  @click="editRecipe(recipe)"
                   class="absolute top-2 right-2 text-green-600 hover:text-green-800 p-1 rounded"
                   title="Editar receta"
+                  @click="editRecipe(recipe)"
                 >
                   <action-button-solid-icon
                     icon="PencilIcon"
@@ -140,7 +141,10 @@
                 </div>
               </div>
             </div>
-            <div v-else class="text-gray-400 italic py-4">
+            <div
+              v-else
+              class="text-gray-400 italic py-4"
+            >
               {{ $t("patients.no-prescription") }}
             </div>
           </div>
@@ -162,7 +166,10 @@
                 <div class="font-medium text-gray-800">
                   {{ exam.name || exam.type }}
                 </div>
-                <div v-if="exam.result" class="text-sm text-gray-600 mt-1">
+                <div
+                  v-if="exam.result"
+                  class="text-sm text-gray-600 mt-1"
+                >
                   <strong>Resultado:</strong> {{ exam.result }}
                 </div>
                 <div
@@ -176,7 +183,10 @@
           </div>
 
           <!-- Observaciones generales -->
-          <div v-if="record?.observations" class="bg-yellow-50 rounded-lg p-4">
+          <div
+            v-if="record?.observations"
+            class="bg-yellow-50 rounded-lg p-4"
+          >
             <h3 class="text-lg font-semibold mb-3 text-yellow-800">
               {{ $t("general.observations") }}
             </h3>
@@ -190,8 +200,8 @@
       <!-- Footer con acciones -->
       <div class="flex justify-end gap-3 p-6 border-t bg-gray-50">
         <button
-          @click="editRecord"
           class="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors flex items-center gap-2"
+          @click="editRecord"
         >
           <action-button-solid-icon
             icon="PencilIcon"
@@ -201,8 +211,8 @@
           {{ $t("general.edit") }}
         </button>
         <button
-          @click="downloadRecord"
           class="px-4 py-2 bg-green-500 text-white rounded-lg hover:bg-green-600 transition-colors flex items-center gap-2"
+          @click="downloadRecord"
         >
           <action-button-solid-icon
             icon="ArrowDownTrayIcon"
@@ -212,8 +222,8 @@
           {{ $t("general.download") }}
         </button>
         <button
-          @click="$emit('close')"
           class="px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors"
+          @click="$emit('close')"
         >
           {{ $t("general.close") }}
         </button>
@@ -254,7 +264,7 @@ function formatRecordDate(dateString) {
       minute: "2-digit",
     });
   } catch (error) {
-    return "Fecha inválida";
+    return error;
   }
 }
 
@@ -263,12 +273,10 @@ function editRecord() {
 }
 
 function editEvolutionNote() {
-  // Abrir modal de edición de medical record
   openEditModal(props.record);
 }
 
 function editRecipe(recipe) {
-  // Abrir modal de edición de receta
   openRecipeFormModal(recipe);
 }
 

--- a/frontend-app/src/components/patientsComponents/PatientContactDataBox.vue
+++ b/frontend-app/src/components/patientsComponents/PatientContactDataBox.vue
@@ -54,7 +54,7 @@ const gmailList = computed(() => {
       (c) =>
         c && typeof c === "object" && c.gmail && typeof c.gmail === "object",
     )
-    .flatMap((c) => Object.values(c.gmail)); // accede a todos los correos del objeto gmail
+    .flatMap((c) => Object.values(c.gmail));
 
   const filteredEmails = allEmails.filter(
     (email) => email != null && email !== "",

--- a/frontend-app/src/components/patientsComponents/PatientContactDataBox.vue
+++ b/frontend-app/src/components/patientsComponents/PatientContactDataBox.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="flex justify-between items-center mx-4 my-4">
     <div class="flex flex-col">
-      <span v-for="(item, index) in contactList" :key="index" class="flex my-2">
+      <span
+        v-for="(item, index) in contactList"
+        :key="index"
+        class="flex my-2"
+      >
         <action-button-solid-icon
           icon="PhoneIcon"
           size="h-10 w-10"
@@ -31,8 +35,6 @@
 </template>
 <script setup>
 import { computed } from "vue";
-import { formatAgeFromDate } from "@utils/formatAge";
-import { normalizeGender } from "@utils/normalizeGender";
 
 import ActionButtonSolidIcon from "@components/forms/ActionButtonSolidIcon.vue";
 

--- a/frontend-app/src/components/patientsComponents/PatientDataSheetBox.vue
+++ b/frontend-app/src/components/patientsComponents/PatientDataSheetBox.vue
@@ -1,11 +1,13 @@
 <template>
   <div class="flex mx-7 my-4 justify-between items-center">
-    <h1 class="text-2xl">{{ $t("patients.data-sheet") }}</h1>
+    <h1 class="text-2xl">
+      {{ $t("patients.data-sheet") }}
+    </h1>
     <action-button-solid-icon
-      @click="props.viewDataSheet && props.viewDataSheet()"
       icon="EyeIcon"
       size="h-10 w-10"
       color="text-patient-page-color"
+      @click="props.viewDataSheet && props.viewDataSheet()"
     />
   </div>
 </template>

--- a/frontend-app/src/components/patientsComponents/PatientHistoryLogBox.vue
+++ b/frontend-app/src/components/patientsComponents/PatientHistoryLogBox.vue
@@ -1,7 +1,9 @@
 <template>
   <div>
     <div class="flex justify-between items-center mb-4">
-      <p class="text-2xl font-bold">{{ $t("patients.patient-history") }}</p>
+      <p class="text-2xl font-bold">
+        {{ $t("patients.patient-history") }}
+      </p>
 
       <!-- Botón para agregar nuevo registro -->
       <div class="flex align-center items-center">
@@ -37,7 +39,10 @@
                   {{ formatDateShort(item.createdAt) }}
                 </p>
               </div>
-              <p v-if="item.diagnosis" class="text-sm text-gray-600 ml-5">
+              <p
+                v-if="item.diagnosis"
+                class="text-sm text-gray-600 ml-5"
+              >
                 <strong>Diagnóstico:</strong> {{ item.diagnosis }}
               </p>
             </div>
@@ -79,13 +84,21 @@
         <label class="text-sm text-gray-600">{{ $t("general.show") }}:</label>
         <select
           v-model="itemsPerPage"
-          @change="resetPagination"
           class="px-2 py-1 border rounded text-sm"
+          @change="resetPagination"
         >
-          <option value="5">5</option>
-          <option value="10">10</option>
-          <option value="15">15</option>
-          <option value="20">20</option>
+          <option value="5">
+            5
+          </option>
+          <option value="10">
+            10
+          </option>
+          <option value="15">
+            15
+          </option>
+          <option value="20">
+            20
+          </option>
         </select>
         <span class="text-sm text-gray-600">{{ $t("general.elements") }}</span>
       </div>
@@ -94,9 +107,9 @@
         class="flex justify-between items-center mt-4 text-sm text-gray-600"
       >
         <button
-          @click="goToPreviousPage"
           :disabled="currentPage === 1"
           class="px-3 py-1 border rounded disabled:opacity-50"
+          @click="goToPreviousPage"
         >
           {{ $t("general.previous") || "Anterior" }}
         </button>
@@ -107,9 +120,9 @@
         </span>
 
         <button
-          @click="goToNextPage"
           :disabled="currentPage === totalPages"
           class="px-3 py-1 border rounded disabled:opacity-50"
+          @click="goToNextPage"
         >
           {{ $t("general.next") || "Siguiente" }}
         </button>
@@ -131,7 +144,7 @@
     <consultation-details-modal
       v-if="showDetailsModal"
       :record="selectedRecord"
-      :is-open="showDetailsModal"
+      :isOpen="showDetailsModal"
       @close="closeHistoryLogModals"
       @view-recipe="handleViewRecipe"
       @edit="openMedicalRecordEditModal"
@@ -140,10 +153,10 @@
     <!-- Modal de formulario -->
     <medical-record-form-modal
       v-if="showFormModal"
-      :is-open="showFormModal"
-      :patient-id="currentPatientSelectedId || props.patientId"
+      :isOpen="showFormModal"
+      :patientId="currentPatientSelectedId || props.patientId"
       :record="selectedRecordForEdit"
-      :is-editing="isEditing"
+      :isEditing="isEditing"
       @close="closeHistoryLogModals"
       @save="(formData) => handleMedicalRecordSave(formData, props.patientId)"
     />
@@ -151,10 +164,10 @@
     <!-- Modal de formulario de recetas -->
     <recipe-form-modal
       v-if="showRecipeFormModal"
-      :is-open="showRecipeFormModal"
+      :isOpen="showRecipeFormModal"
       :recipe="selectedRecipeForEdit"
-      :is-editing="isEditingRecipe"
-      :treatment-id="getFirstTreatmentId()"
+      :isEditing="isEditingRecipe"
+      :treatmentId="getFirstTreatmentId()"
       @close="closeHistoryLogModals"
       @save="(recipeData) => handleRecipeSave(recipeData, props.patientId)"
     />
@@ -169,9 +182,6 @@ import { storeToRefs } from "pinia";
 import { DocumentIcon } from "@heroicons/vue/24/outline";
 
 import ActionButtonSolidIcon from "@components/forms/ActionButtonSolidIcon.vue";
-import ActionButtonOutlinedIcon from "@components/forms/ActionButtonOutlinedIcon.vue";
-import PrimaryButton from "@components/forms/PrimaryButton.vue";
-import Panel from "@components/forms/Panel.vue";
 import ConsultationDetailsModal from "../patientsDialogsComponents/ConsultationDetailsModal.vue";
 import MedicalRecordFormModal from "../patientsDialogsComponents/MedicalRecordFormModal.vue";
 import RecipeFormModal from "../patientsDialogsComponents/RecipeFormModal.vue";
@@ -190,7 +200,6 @@ const emit = defineEmits(["view-recipe"]);
 const patientsStore = usePatientsStore();
 const {
   currentPatientMedicalRecords,
-  isLoadingMedicalRecords,
   currentPatientSelectedId,
 } = storeToRefs(patientsStore);
 const patientsLogicStore = usePatientsLogicStore();
@@ -241,8 +250,7 @@ async function deleteRecord(record) {
     await patientsStore.fetchPatientMedicalRecords(props.patientId);
     alert("Registro eliminado correctamente");
   } catch (error) {
-    console.error("Error al eliminar registro:", error);
-    alert("Error al eliminar el registro");
+    return error;
   }
 }
 
@@ -253,7 +261,6 @@ function downloadRecord(record) {
 
 function handleViewRecipe(recipe) {
   emit("view-recipe", recipe);
-  closeDetailsModal();
 }
 
 function getFirstTreatmentId() {

--- a/frontend-app/src/components/patientsComponents/PatientMainDataBox.vue
+++ b/frontend-app/src/components/patientsComponents/PatientMainDataBox.vue
@@ -1,8 +1,12 @@
 <template>
   <div class="flex justify-between items-center mx-6 my-4">
     <div class="flex flex-col">
-      <h1 class="text-3xl font-bold">{{ data.name }}</h1>
-      <h1 class="text-3xl font-bold">{{ data.lastName }}</h1>
+      <h1 class="text-3xl font-bold">
+        {{ data.name }}
+      </h1>
+      <h1 class="text-3xl font-bold">
+        {{ data.lastName }}
+      </h1>
     </div>
     <div class="flex flex-col">
       <p>{{ $t("general.age") }}: {{ ageNumber }}</p>
@@ -11,22 +15,21 @@
     </div>
     <div class="flex justify-between">
       <action-button-solid-icon
-        @click="props.createAction && props.createAction()"
         icon="PlusIcon"
         size="h-16 w-16"
         color="text-patient-page-color"
+        @click="props.createAction && props.createAction()"
       />
       <action-button-solid-icon
-        @click="props.chartAction && props.chartAction()"
         icon="ChartBarSquareIcon"
         size="h-16 w-16"
         color="text-patient-page-color"
+        @click="props.chartAction && props.chartAction()"
       />
     </div>
   </div>
 </template>
 <script setup>
-import { ref } from "vue";
 import { formatAgeFromDate } from "@utils/formatAge";
 import { normalizeGender } from "@utils/normalizeGender";
 

--- a/frontend-app/src/components/patientsComponents/PatientsSearch.vue
+++ b/frontend-app/src/components/patientsComponents/PatientsSearch.vue
@@ -2,10 +2,10 @@
   <div class="w-full flex items-center justify-center">
     <div class="w-full max-w-xl">
       <combo-box-autocomplete-input
-        :data="allPatients"
         v-model:currentSelected="currentPatientSelectedId"
-        @update:currentSelected="patientsStore.setPatientsData"
+        :data="allPatients"
         :placeholder="$t('general.search-patient')"
+        @update:current-selected="patientsStore.setPatientsData"
       />
     </div>
   </div>

--- a/frontend-app/src/components/patientsDialogsComponents/ConsultationDetailsModal.vue
+++ b/frontend-app/src/components/patientsDialogsComponents/ConsultationDetailsModal.vue
@@ -1,9 +1,9 @@
 <template>
   <general-dialog-modal
     ref="createDialog"
-    @close-modal="handleClose"
     :isOpen="isOpen"
     dialogSize="max-w-6xl"
+    @close-modal="handleClose"
   >
     <!-- Header -->
     <template #title>
@@ -17,8 +17,8 @@
           </p>
         </div>
         <button
-          @click="handleClose"
           class="text-black hover:text-gray-400 text-3xl font-bold leading-none"
+          @click="handleClose"
         >
           ×
         </button>
@@ -36,40 +36,39 @@
           <div
             class="animate-spin h-12 w-12 border-4 border-gray-300 border-t-[#489FB5] rounded-full"
           ></div>
-          <p class="mt-4 text-gray-600">{{ $t("general.loading") }}...</p>
+          <p class="mt-4 text-gray-600">
+            {{ $t("general.loading") }}...
+          </p>
         </div>
 
         <!-- Content -->
-        <div v-else-if="displayRecord" class="p-6 space-y-6">
+        <div
+          v-else-if="displayRecord"
+          class="p-6 space-y-6"
+        >
           <div class="bg-gray-100 rounded-lg p-4">
             <h3 class="text-lg font-bold text-gray-800 mb-3">
               {{ $t("general.general-info") }}
             </h3>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <span class="text-sm text-gray-600 font-semibold"
-                  >{{ $t("general.date") }}:</span
-                >
+                <span class="text-sm text-gray-600 font-semibold">{{ $t("general.date") }}:</span>
                 <p class="text-gray-800 font-medium">
                   {{ formatDate(displayRecord.createdAt) }}
                 </p>
               </div>
               <div v-if="displayRecord.patient">
-                <span class="text-sm text-gray-600 font-semibold"
-                  >{{ $t("general.patient") }}:</span
-                >
+                <span class="text-sm text-gray-600 font-semibold">{{ $t("general.patient") }}:</span>
                 <p class="text-gray-800 font-medium">
                   {{
                     displayRecord.patient.name ||
-                    displayRecord.patient.firstName
+                      displayRecord.patient.firstName
                   }}
                   {{ displayRecord.patient.lastName }}
                 </p>
               </div>
               <div>
-                <span class="text-sm text-gray-600 font-semibold"
-                  >{{ $t("general.status") }}:</span
-                >
+                <span class="text-sm text-gray-600 font-semibold">{{ $t("general.status") }}:</span>
                 <span
                   class="inline-block px-3 py-1 text-sm font-bold rounded-full text-white"
                   style="background-color: #48c9b0"
@@ -78,25 +77,19 @@
                 </span>
               </div>
               <div v-if="displayRecord.diagnosis">
-                <span class="text-sm text-gray-600 font-semibold"
-                  >{{ $t("general.diagnosis") }}:</span
-                >
+                <span class="text-sm text-gray-600 font-semibold">{{ $t("general.diagnosis") }}:</span>
                 <p class="text-gray-800 font-medium">
                   {{ displayRecord.diagnosis }}
                 </p>
               </div>
               <div v-if="displayRecord.weight">
-                <span class="text-sm text-gray-600 font-semibold"
-                  >{{ $t("patients.weight") }}:</span
-                >
+                <span class="text-sm text-gray-600 font-semibold">{{ $t("patients.weight") }}:</span>
                 <p class="text-gray-800 font-medium">
                   {{ displayRecord.weight }} kg
                 </p>
               </div>
               <div v-if="displayRecord.height">
-                <span class="text-sm text-gray-600 font-semibold"
-                  >{{ $t("patients.height") }}:</span
-                >
+                <span class="text-sm text-gray-600 font-semibold">{{ $t("patients.height") }}:</span>
                 <p class="text-gray-800 font-medium">
                   {{ displayRecord.height }} cm
                 </p>
@@ -139,8 +132,8 @@
                 </h3>
               </div>
               <button
-                @click="editEvolutionNote"
                 class="px-3 py-1 text-blue-600 hover:text-blue-800 text-sm font-medium rounded flex items-center gap-1"
+                @click="editEvolutionNote"
               >
                 ✏️ {{ $t("general.edit") }}
               </button>
@@ -157,7 +150,7 @@
             <div
               v-else-if="
                 displayRecord.medicalRecord?.notes &&
-                displayRecord.medicalRecord.notes.trim()
+                  displayRecord.medicalRecord.notes.trim()
               "
               class="bg-white rounded p-3 border-l-4"
               style="border-color: #489fb5"
@@ -166,14 +159,19 @@
                 {{ displayRecord.medicalRecord.notes }}
               </p>
             </div>
-            <div v-else class="text-center py-6">
-              <div class="text-gray-400 text-4xl mb-2">📝</div>
+            <div
+              v-else
+              class="text-center py-6"
+            >
+              <div class="text-gray-400 text-4xl mb-2">
+                📝
+              </div>
               <p class="text-gray-500">
                 {{ $t("patients.no-evolution-note") }}
               </p>
               <button
-                @click="editEvolutionNote"
                 class="mt-3 px-4 py-2 text-blue-600 hover:text-blue-800 font-medium"
+                @click="editEvolutionNote"
               >
                 ✏️ {{ $t("general.edit") }}
               </button>
@@ -203,9 +201,9 @@
                 class="bg-white rounded-lg p-4 border relative"
               >
                 <button
-                  @click="openRecipeFormModal(recipe)"
                   class="absolute top-3 right-3 px-2 py-1 text-green-600 hover:text-green-800 text-sm font-medium rounded flex items-center gap-1"
                   title="Editar receta"
+                  @click="openRecipeFormModal(recipe)"
                 >
                   ✏️ Editar
                 </button>
@@ -215,24 +213,30 @@
                 <div class="bg-gray-50 rounded p-3 mb-3">
                   <pre
                     class="text-gray-800 text-sm whitespace-pre-wrap font-mono"
-                    >{{ recipe.prescription }}</pre
-                  >
+                  >{{ recipe.prescription }}</pre>
                 </div>
                 <button
-                  @click="viewFullRecipe(recipe)"
                   class="px-4 py-2 text-white rounded-lg font-semibold hover:opacity-90 transition-opacity"
                   style="background-color: var(--primary-color)"
+                  @click="viewFullRecipe(recipe)"
                 >
                   {{ $t("patients.view-full-recipe") }}
                 </button>
               </div>
             </div>
-            <div v-else class="text-center py-6">
-              <div class="text-gray-400 text-4xl mb-2">💊</div>
-              <p class="text-gray-500">{{ $t("patients.no-prescription") }}</p>
+            <div
+              v-else
+              class="text-center py-6"
+            >
+              <div class="text-gray-400 text-4xl mb-2">
+                💊
+              </div>
+              <p class="text-gray-500">
+                {{ $t("patients.no-prescription") }}
+              </p>
               <button
-                @click="openRecipeFormModal()"
                 class="mt-3 px-4 py-2 text-blue-600 hover:text-blue-800 font-medium"
+                @click="openRecipeFormModal()"
               >
                 ✏️ {{ $t("general.edit") }}
               </button>
@@ -276,7 +280,10 @@
                 >
                   <strong>Descripción:</strong> {{ exam.exam.description }}
                 </div>
-                <div v-if="exam.resultText" class="bg-gray-50 rounded p-3 mb-2">
+                <div
+                  v-if="exam.resultText"
+                  class="bg-gray-50 rounded p-3 mb-2"
+                >
                   <div class="text-sm text-gray-600 mb-1 font-semibold">
                     Resultados:
                   </div>
@@ -347,7 +354,9 @@
                   <div class="text-sm text-gray-600 mb-1 font-semibold">
                     Observaciones:
                   </div>
-                  <p class="text-gray-800">{{ treatment.observations }}</p>
+                  <p class="text-gray-800">
+                    {{ treatment.observations }}
+                  </p>
                 </div>
               </div>
             </div>
@@ -355,8 +364,13 @@
         </div>
 
         <!-- Error -->
-        <div v-else-if="hasError" class="text-center py-16">
-          <div class="text-red-500 text-6xl mb-4">⚠️</div>
+        <div
+          v-else-if="hasError"
+          class="text-center py-16"
+        >
+          <div class="text-red-500 text-6xl mb-4">
+            ⚠️
+          </div>
           <h3 class="text-xl font-bold text-red-600 mb-2">
             {{ $t("general.error-loading-data") }}
           </h3>
@@ -364,9 +378,9 @@
             No se pudieron cargar los detalles de la consulta
           </p>
           <button
-            @click="loadFullRecord"
             class="px-6 py-3 text-white rounded-lg font-semibold hover:opacity-90 transition-opacity"
             style="background-color: #489fb5"
+            @click="loadFullRecord"
           >
             {{ $t("general.retry") }}
           </button>
@@ -376,11 +390,19 @@
 
     <!-- Footer -->
     <template #buttons>
-      <primary-button @click="editRecord" class="mr-2" bgColor="orange">
-        <p class="uppercase">{{ $t("general.edit") }}</p>
+      <primary-button
+        class="mr-2"
+        bgColor="orange"
+        @click="editRecord"
+      >
+        <p class="uppercase">
+          {{ $t("general.edit") }}
+        </p>
       </primary-button>
       <primary-button @click="downloadRecord">
-        <p class="uppercase">{{ $t("general.download") }}</p>
+        <p class="uppercase">
+          {{ $t("general.download") }}
+        </p>
       </primary-button>
     </template>
   </general-dialog-modal>
@@ -398,8 +420,14 @@ import PrimaryButton from "@components/forms/PrimaryButton.vue";
 import GeneralDialogModal from "@components/forms/GeneralDialogModal.vue";
 
 const props = defineProps({
-  record: Object,
-  isOpen: Boolean,
+  record: {
+    type: Object,
+    default: null,
+  },
+  isOpen: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 const emit = defineEmits(["close", "view-recipe", "edit", "download"]);
@@ -416,25 +444,6 @@ const {
   openRecipeFormModal,
 } = patientsLogicStore;
 
-function getFirstTreatmentId() {
-  // Si estamos editando una receta existente, usar su treatmentId
-  if (displayRecord.value?.recipes && displayRecord.value.recipes.length > 0) {
-    const firstRecipe = displayRecord.value.recipes[0];
-    if (firstRecipe.treatmentId) return firstRecipe.treatmentId;
-  }
-
-  // Si hay tratamientos disponibles, usar el primero
-  if (
-    displayRecord.value?.treatments &&
-    displayRecord.value.treatments.length > 0
-  ) {
-    return displayRecord.value.treatments[0].id;
-  }
-
-  // Si no hay tratamientos, retornar un ID por defecto o null
-  return 1; // Por ahora usar 1 como fallback
-}
-
 const handleClose = () => {
   closeHistoryLogModals();
 };
@@ -443,21 +452,6 @@ const displayRecord = computed(() => fullRecord.value);
 // 🎯 Solo llama a la store (sin try/catch)
 async function loadFullRecord() {
   await patientsStore.fetchMedicalRecordDetails(selectedRecord.value.id);
-}
-
-function formatRecordDate(dateString) {
-  if (!dateString) return "Fecha no disponible";
-  try {
-    return new Date(dateString).toLocaleDateString("es-ES", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-  } catch {
-    return "Fecha inválida";
-  }
 }
 
 function editRecord() {

--- a/frontend-app/src/components/patientsDialogsComponents/PatientsCreateFormDialog.vue
+++ b/frontend-app/src/components/patientsDialogsComponents/PatientsCreateFormDialog.vue
@@ -107,23 +107,6 @@ function handleSendFiles(fileReceived) {
     newPatientData.value.file = null;
   }
 }
-function downloadFile(patientId, type, medicalRecordID) {
-  patientsStore
-    .downloadFile(1, "laboratorios", 1)
-    .then((blob) => {
-      const url = window.URL.createObjectURL(new Blob([blob]));
-      const link = document.createElement("a");
-      link.href = url;
-      link.setAttribute("download", `ficha_datos_${patientId}.pdf`); //or any other extension
-      document.body.appendChild(link);
-      link.click();
-      link.parentNode.removeChild(link);
-      window.URL.revokeObjectURL(url);
-    })
-    .catch((error) => {
-      console.error("Error downloading file:", error);
-    });
-}
 
 function nextPage() {
   currentPage.value += 1;

--- a/frontend-app/src/components/patientsDialogsComponents/PatientsCreateFormDialog.vue
+++ b/frontend-app/src/components/patientsDialogsComponents/PatientsCreateFormDialog.vue
@@ -1,14 +1,16 @@
 <template>
   <general-dialog-modal
     ref="createDialog"
-    @close-modal="handleClose"
     :isOpen="isOpen"
     dialogSize="max-w-6xl"
+    @close-modal="handleClose"
   >
     <template #title>
       <div class="flex justify-between items-center px-6 py-2 border-b">
         <div>
-          <p class="text-xl">{{ $t("patients.fill-out-form") }}</p>
+          <p class="text-xl">
+            {{ $t("patients.fill-out-form") }}
+          </p>
         </div>
       </div>
     </template>
@@ -16,10 +18,13 @@
       <div class="grid grid-cols-2">
         <div>
           <drag-drop-file-input
-            @sendFiles="handleSendFiles"
             title="patients.drag-or-click-here-to-load-the-PDF-of-the-data-sheet"
+            @send-files="handleSendFiles"
           />
-          <general-i-frame v-if="file" :source="file" />
+          <general-i-frame
+            v-if="file"
+            :source="file"
+          />
         </div>
         <div class="ml-2 sm:border-l">
           <create-new-patients-form v-if="currentPage === 1" />
@@ -31,14 +36,22 @@
       <primary-button
         v-if="currentPage === 2"
         type="button"
-        @click="backPage()"
         bgColor="orange"
         class="mr-2"
+        @click="backPage()"
       >
-        <div class="uppercase">{{ $t("general.back") }}</div>
+        <div class="uppercase">
+          {{ $t("general.back") }}
+        </div>
       </primary-button>
-      <primary-button type="button" @click="nextPage()" class="mr-2">
-        <div class="uppercase">{{ $t("general.accept") }}</div>
+      <primary-button
+        type="button"
+        class="mr-2"
+        @click="nextPage()"
+      >
+        <div class="uppercase">
+          {{ $t("general.accept") }}
+        </div>
       </primary-button>
     </template>
   </general-dialog-modal>
@@ -47,7 +60,7 @@
 import { usePatientsLogicStore } from "@stores/patientsLogicStore.js";
 import { usePatientsStore } from "@stores/patientsStore.js";
 import { useBlobAdapter } from "@/composables/useBlobAdapter";
-import { ref, defineAsyncComponent, computed, watchEffect } from "vue";
+import { ref, computed } from "vue";
 import { storeToRefs } from "pinia";
 
 import GeneralDialogModal from "@components/forms/GeneralDialogModal.vue";
@@ -58,7 +71,7 @@ import PrimaryButton from "@components/forms/PrimaryButton.vue";
 import GeneralIFrame from "@components/forms/GeneralIFrame.vue";
 
 const patientsStore = usePatientsStore();
-const { currentPatientSelectedData, newPatientData } =
+const { newPatientData } =
   storeToRefs(patientsStore);
 
 const patientsLogicStore = usePatientsLogicStore();
@@ -68,34 +81,12 @@ const handleClose = (closeModal) => {
   showCreateFormDialog.value = closeModal;
 };
 
-const props = defineProps({
-  contractCategoryId: {
-    type: Number || null,
-    default: null,
-  },
-  id: {
-    type: Number || null,
-    default: null,
-  },
-  isOpen: {
-    type: Boolean,
-    default: false,
-  },
-});
 const rawFile = ref(newPatientData.value.file ?? null);
 const file = computed(() => blobUrl.value);
 const { blobUrl, generate } = useBlobAdapter(rawFile, {
   mimeType: "application/pdf",
 });
 const currentPage = ref(1);
-const patientData = computed(() => currentPatientSelectedData.value);
-
-const showDialog = computed({
-  get: () => patientsLogicStore.showDataSheetPatientDialog,
-  set: (val) => {
-    patientsLogicStore.showDataSheetPatientDialog = val;
-  },
-});
 
 function handleSendFiles(fileReceived) {
   rawFile.value = fileReceived;

--- a/frontend-app/src/components/patientsDialogsComponents/RecipeFormModal.vue
+++ b/frontend-app/src/components/patientsDialogsComponents/RecipeFormModal.vue
@@ -1,6 +1,6 @@
 <template>
   <general-dialog-modal
-    :is-open="isOpen"
+    :isOpen="isOpen"
     dialogSize="max-w-2xl"
     @close-modal="handleClose"
   >
@@ -12,14 +12,19 @@
     <template #body>
       <div class="space-y-6 max-h-[70vh] overflow-y-auto">
         <!-- Formulario principal -->
-        <form @submit.prevent="handleSubmit" class="space-y-4">
+        <form
+          class="space-y-4"
+          @submit.prevent="handleSubmit"
+        >
           <!-- Alerta si no hay treatmentId -->
           <div
             v-if="!props.isEditing && !props.treatmentId"
             class="bg-yellow-50 border border-yellow-200 rounded-lg p-4"
           >
             <div class="flex items-center">
-              <div class="text-yellow-400 text-lg mr-2">⚠️</div>
+              <div class="text-yellow-400 text-lg mr-2">
+                ⚠️
+              </div>
               <div>
                 <h4 class="text-yellow-800 font-semibold">
                   {{ $t("recipes.warning") }}
@@ -33,7 +38,9 @@
 
           <!-- Información de la receta -->
           <div class="bg-gray-50 p-4 rounded-lg">
-            <h3 class="text-lg font-semibold mb-4">Receta médica</h3>
+            <h3 class="text-lg font-semibold mb-4">
+              Receta médica
+            </h3>
 
             <!-- Prescripción -->
             <div>
@@ -47,16 +54,18 @@
                 class="mb-3 text-xs text-gray-500 bg-gray-50 p-3 rounded border"
               >
                 <div class="flex items-center justify-between">
+                  <span>📅 <strong>{{ $t("recipes.creation-date") }}:</strong>
+                    {{ formatDate(originalValues.createdAt) }}</span>
                   <span
-                    >📅 <strong>{{ $t("recipes.creation-date") }}:</strong>
-                    {{ formatDate(originalValues.createdAt) }}</span
-                  >
-                  <span v-if="originalValues.updatedAt" class="ml-4"
-                    >✏️ <strong>{{ $t("recipes.last-edit") }}:</strong>
-                    {{ formatDate(originalValues.updatedAt) }}</span
-                  >
+                    v-if="originalValues.updatedAt"
+                    class="ml-4"
+                  >✏️ <strong>{{ $t("recipes.last-edit") }}:</strong>
+                    {{ formatDate(originalValues.updatedAt) }}</span>
                 </div>
-                <div v-if="originalValues.treatmentId" class="mt-1">
+                <div
+                  v-if="originalValues.treatmentId"
+                  class="mt-1"
+                >
                   🔗 <strong>{{ $t("recipes.treatment-id") }}:</strong>
                   {{ originalValues.treatmentId }}
                 </div>
@@ -78,7 +87,10 @@
 
     <!-- Botones de acción -->
     <template #buttons>
-      <primary-button v-if="isLoading" :disabled="isLoading">
+      <primary-button
+        v-if="isLoading"
+        :disabled="isLoading"
+      >
         <span class="flex items-center">
           <svg
             class="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
@@ -93,20 +105,20 @@
               r="10"
               stroke="currentColor"
               stroke-width="4"
-            ></circle>
+            />
             <path
               class="opacity-75"
               fill="currentColor"
               d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-            ></path>
+            />
           </svg>
           {{ $t("recipes.saving") }}
         </span>
       </primary-button>
       <primary-button
         v-else
-        @click="handleSubmit"
         :disabled="isLoading || !formData.prescription.trim()"
+        @click="handleSubmit"
       >
         <p class="uppercase">
           {{ $t(isEditing ? "general.update" : "general.save") }}
@@ -117,7 +129,7 @@
 </template>
 
 <script setup>
-import { ref, watch, nextTick, computed } from "vue";
+import { ref, watch, nextTick } from "vue";
 import { useI18n } from "vue-i18n";
 import { usePatientsStore } from "@stores/patientsStore.js";
 import { usePatientsLogicStore } from "@stores/patientsLogicStore.js";
@@ -126,8 +138,6 @@ import { formatDate } from "@utils/isoFormatDate.js";
 
 import GeneralDialogModal from "@components/forms/GeneralDialogModal.vue";
 import PrimaryButton from "@components/forms/PrimaryButton.vue";
-import CustomLabel from "@components/forms/CustomLabel.vue";
-import { storeToRefs } from "pinia";
 
 const props = defineProps({
   isOpen: {

--- a/frontend-app/src/components/patientsDialogsComponents/patientsCreateDialogComponents/CreateNewPatientsForm.vue
+++ b/frontend-app/src/components/patientsDialogsComponents/patientsCreateDialogComponents/CreateNewPatientsForm.vue
@@ -32,23 +32,26 @@
     />
     <!-- gender input -->
     <radio-group
+      v-model:currentSelected="currentGender"
       title="patients.gender"
       :data="genders"
-      v-model:currentSelected="currentGender"
       class="mt-2 col-span-2 sm:col-span-1"
     />
 
     <!-- alergies selector -->
     <radio-group
+      v-model:currentSelected="hasAlergies"
       title="patients.suffer-from-allergies"
       :data="yesnoOptions"
-      v-model:currentSelected="hasAlergies"
       class="mt-2 sm:col-span-2"
     />
-    <div v-if="hasAlergies === 0" class="w-full col-span-2">
+    <div
+      v-if="hasAlergies === 0"
+      class="w-full col-span-2"
+    >
       <comboboxes-input
-        :data="alergies"
         v-model:currentSelected="currentAlergies"
+        :data="alergies"
         title="patients.alergies"
         placeholder="patients.alergies-placeholder"
         class="mt-2 sm:col-span-2"
@@ -57,15 +60,18 @@
 
     <!-- syndrome selector -->
     <radio-group
+      v-model:currentSelected="hasSyndromes"
       title="patients.suffer-from-syndromes"
       :data="yesnoOptions"
-      v-model:currentSelected="hasSyndromes"
       class="mt-2 sm:col-span-2"
     />
-    <div v-if="hasSyndromes === 0" class="w-full col-span-2">
+    <div
+      v-if="hasSyndromes === 0"
+      class="w-full col-span-2"
+    >
       <comboboxes-input
-        :data="syndrome"
         v-model:currentSelected="currentSyndromes"
+        :data="syndrome"
         title="patients.syndrome"
         placeholder="patients.syndrome-placeholder"
         class="mt-2 sm:col-span-2"
@@ -108,11 +114,14 @@
     <!-- phone input -->
     <div class="sm:col-span-2 space-y-2">
       <div class="flex items-center items-start">
-        <custom-label title="patients.phone-contact" :is-required="true" />
+        <custom-label
+          title="patients.phone-contact"
+          :isRequired="true"
+        />
         <action-button-outline-icon
-          @click="addPhone()"
           icon="PlusIcon"
           color="text-patient-page-color"
+          @click="addPhone()"
         />
       </div>
       <div
@@ -129,17 +138,17 @@
           class="w-full"
         />
         <action-button-outline-icon
-          @click="deletePhone(item.id)"
           icon="TrashIcon"
           color="text-red-500"
+          @click="deletePhone(item.id)"
         />
       </div>
     </div>
 
     <!-- insurance selector -->
     <comboboxes-input
-      :data="insurances"
       v-model:currentSelected="currentInsurance"
+      :data="insurances"
       title="patients.insurance"
       placeholder="patients.insurance-placeholder"
       class="mt-2 sm:col-span-2"
@@ -170,13 +179,11 @@
 </template>
 <script setup>
 import { useForm } from "vee-validate";
-import { ref, watchEffect, computed, watch } from "vue";
+import { ref, watchEffect, computed } from "vue";
 import { usePatientsStore } from "@stores/patientsStore.js";
 import { storeToRefs } from "pinia";
-import { DateTime } from "luxon";
 import * as yup from "yup";
 
-import ActionButtonSolidIcon from "@components/forms/ActionButtonSolidIcon.vue";
 import ActionButtonOutlineIcon from "@components/forms/ActionButtonOutlinedIcon.vue";
 import CustomLabel from "@/components/forms/CustomLabel.vue";
 import TextInput from "@components/forms/TextInput.vue";

--- a/frontend-app/src/components/patientsDialogsComponents/patientsCreateDialogComponents/ReviewPatientData.vue
+++ b/frontend-app/src/components/patientsDialogsComponents/patientsCreateDialogComponents/ReviewPatientData.vue
@@ -14,7 +14,9 @@
             item.css,
           ]"
         >
-          <dt class="text-sm/6 text-gray-600">{{ $t(item.name) }}</dt>
+          <dt class="text-sm/6 text-gray-600">
+            {{ $t(item.name) }}
+          </dt>
           <dd
             class="order-first text-lg font-semibold tracking-tight text-gray-900"
           >
@@ -33,7 +35,7 @@
         <div
           class="relative flex size-6 flex-none items-center justify-center bg-white"
         >
-          <div class="size-1.5 rounded-full bg-gray-100 ring-1 ring-gray-300" />
+          <div class="size-1.5 rounded-full bg-gray-100 ring-1 ring-gray-300"></div>
         </div>
         <p class="flex-auto py-0.5 text-xs/5 text-gray-500">
           <span class="text-lg font-semibold font-medium text-gray-900">
@@ -48,7 +50,7 @@
 import { usePatientsStore } from "@stores/patientsStore.js";
 import { isoFormatDate } from "@utils/isoFormatDate";
 import { storeToRefs } from "pinia";
-import { computed, ref } from "vue";
+import { computed } from "vue";
 
 const patientsStore = usePatientsStore();
 const { newPatientData } = storeToRefs(patientsStore);

--- a/frontend-app/src/components/patientsDialogsComponents/patientsDataSheetDialog.vue
+++ b/frontend-app/src/components/patientsDialogsComponents/patientsDataSheetDialog.vue
@@ -1,18 +1,20 @@
 <template>
   <general-dialog-modal
     ref="createDialog"
-    @close-modal="handleClose"
     :isOpen="isOpen"
     dialogSize="max-w-6xl"
+    @close-modal="handleClose"
   >
     <template #title>
       <div class="flex justify-between items-center px-6 py-2 border-b">
         <div>
-          <p class="text-xl">{{ $t("patients.data-sheet") }}</p>
+          <p class="text-xl">
+            {{ $t("patients.data-sheet") }}
+          </p>
         </div>
         <button
-          @click="handleClose"
           class="text-black hover:text-gray-400 text-3xl font-bold leading-none"
+          @click="handleClose"
         >
           ×
         </button>
@@ -21,7 +23,7 @@
     <template #body>
       <div class="grid grid-cols-2 grid-rows-3 gap-4">
         <div class="col-span-2">
-          <panel>
+          <app-panel>
             <p class="font-bold">
               {{ $t("patients.patients-data") }}
             </p>
@@ -37,35 +39,35 @@
                 <p>{{ item.value }}</p>
               </div>
             </div>
-          </panel>
+          </app-panel>
         </div>
         <div class="row-start-2">
-          <panel>
+          <app-panel>
             <p class="font-bold">
               {{ $t("patients.record") }}
             </p>
-          </panel>
+          </app-panel>
         </div>
         <div class="row-start-2">
-          <panel>
+          <app-panel>
             <p class="font-bold">
               {{ $t("patients.current-illnesses") }}
             </p>
-          </panel>
+          </app-panel>
         </div>
         <div class="row-start-3">
-          <panel>
+          <app-panel>
             <p class="font-bold">
               {{ $t("patients.exams") }}
             </p>
-          </panel>
+          </app-panel>
         </div>
         <div class="row-start-3">
-          <panel>
+          <app-panel>
             <p class="font-bold">
               {{ $t("patients.laboratories") }}
             </p>
-          </panel>
+          </app-panel>
         </div>
       </div>
     </template>
@@ -74,13 +76,11 @@
 <script setup>
 import { usePatientsLogicStore } from "@stores/patientsLogicStore.js";
 import { usePatientsStore } from "@stores/patientsStore.js";
-import { DialogTitle } from "@headlessui/vue";
-import { useForm } from "vee-validate";
-import { ref, defineAsyncComponent, computed } from "vue";
+import { computed } from "vue";
 import { storeToRefs } from "pinia";
 
 import GeneralDialogModal from "@components/forms/GeneralDialogModal.vue";
-import Panel from "@components/forms/Panel.vue";
+import AppPanel from "@components/forms/AppPanel.vue";
 
 const patientsStore = usePatientsStore();
 const { currentPatientSelectedData } = storeToRefs(patientsStore);
@@ -91,21 +91,6 @@ const { showDataSheetPatientDialog } = storeToRefs(patientsLogicStore);
 const handleClose = (closeModal) => {
   showDataSheetPatientDialog.value = closeModal;
 };
-
-const props = defineProps({
-  contractCategoryId: {
-    type: Number || null,
-    default: null,
-  },
-  id: {
-    type: Number || null,
-    default: null,
-  },
-  isOpen: {
-    type: Boolean,
-    default: false,
-  },
-});
 
 const patientData = computed(() => currentPatientSelectedData.value);
 
@@ -121,10 +106,4 @@ const patientInfo = computed(() => [
   { label: "general.sex", value: patientData.value?.gender ?? "" },
 ]);
 
-const showDialog = computed({
-  get: () => patientsLogicStore.showDataSheetPatientDialog,
-  set: (val) => {
-    patientsLogicStore.showDataSheetPatientDialog = val;
-  },
-});
 </script>

--- a/frontend-app/src/stores/notificationStore.js
+++ b/frontend-app/src/stores/notificationStore.js
@@ -26,11 +26,10 @@ export const useNotificationStore = defineStore(
       if (notification) {
         notification.timeoutId = timeoutId;
       }
-      console.log(notifications.value);
     }
 
-    function hideNotification(id) {
-      const notification = notifications.value.find(({ id }) => id === id);
+    function hideNotification(Id) {
+      const notification = notifications.value.find(({ id }) => id === Id);
       const index = notifications.value.indexOf(notification);
       if (notification) {
         notification.visible = false;

--- a/frontend-app/src/stores/patientsStore.js
+++ b/frontend-app/src/stores/patientsStore.js
@@ -51,20 +51,18 @@ export const usePatientsStore = defineStore(
 
     // patientsStore.js
     async function updateAppointmentStatus(id, newStatus) {
+      isLoadingAppointmentsToday.value = true;
       try {
-        const res = await instance.patch(`/appointments/${id}`, {
+        await instance.patch(`/appointments/${id}`, {
           status: newStatus,
         });
-
         const idx = appointmentsToday.value.findIndex((a) => a.id === id);
         if (idx !== -1) {
           appointmentsToday.value[idx].status = newStatus;
         }
-
         return true;
-      } catch (e) {
-        console.error("Error al actualizar estado de cita:", e);
-        return false;
+      } finally {
+        isLoadingAppointmentsToday.value = false;
       }
     }
 
@@ -81,7 +79,6 @@ export const usePatientsStore = defineStore(
     async function fetchPatientData() {
       isLoadingPatientData.value = true;
       if (!currentPatientSelectedId.value) {
-        console.warn("ID de paciente no definido");
         return;
       }
       try {
@@ -113,21 +110,10 @@ export const usePatientsStore = defineStore(
     async function createMedicalRecord(patientId, recordData) {
       isLoadingMedicalRecords.value = true;
       try {
-        console.log(
-          `➕ Creando medical record para paciente ${patientId} con datos:`,
-          recordData,
-        );
         // Asegurar que el PatientId esté en los datos (backend espera PascalCase)
         const dataToSend = { ...recordData, PatientId: patientId };
         const res = await instance.post(`/medicalrecords`, dataToSend);
-        console.log("✅ Medical record creado:", res.data);
         return res.data;
-      } catch (error) {
-        console.error(
-          "❌ Error en createMedicalRecord:",
-          error.response?.data || error.message,
-        );
-        throw error;
       } finally {
         isLoadingMedicalRecords.value = false;
       }
@@ -136,32 +122,11 @@ export const usePatientsStore = defineStore(
     async function updateMedicalRecord(recordId, recordData) {
       isLoadingMedicalRecords.value = true;
       try {
-        console.log(
-          `🔄 Actualizando medical record ${recordId} con datos:`,
-          recordData,
-        );
-        console.log("🔍 URL de la petición:", `/medicalrecords/${recordId}`);
-        console.log("🔍 Tipo de petición: PATCH");
         const res = await instance.patch(
           `/medicalrecords/${recordId}`,
           recordData,
         );
-        console.log("✅ Respuesta del servidor:", res.data);
         return res.data;
-      } catch (error) {
-        console.error(
-          "❌ Error en updateMedicalRecord:",
-          error.response?.data || error.message,
-        );
-        console.error("❌ Status del error:", error.response?.status);
-        console.error("❌ Config de axios:", error.config);
-        if (error.response?.data?.errors) {
-          console.error(
-            "❌ Validation errors detallados:",
-            error.response.data.errors,
-          );
-        }
-        throw error;
       } finally {
         isLoadingMedicalRecords.value = false;
       }
@@ -170,16 +135,8 @@ export const usePatientsStore = defineStore(
     async function deleteMedicalRecord(recordId) {
       isLoadingMedicalRecords.value = true;
       try {
-        console.log(`🗑️ Eliminando medical record ${recordId}`);
         await instance.delete(`/medicalrecords/${recordId}`);
-        console.log("✅ Medical record eliminado");
         return true;
-      } catch (error) {
-        console.error(
-          "❌ Error en deleteMedicalRecord:",
-          error.response?.data || error.message,
-        );
-        throw error;
       } finally {
         isLoadingMedicalRecords.value = false;
       }
@@ -191,9 +148,6 @@ export const usePatientsStore = defineStore(
       try {
         const res = await instance.get(`/medicalrecords/${recordId}/details`);
         fullRecord.value = res.data;
-      } catch (error) {
-        console.error("Error fetching medical record details:", error);
-        hasError.value = true;
       } finally {
         isLoadingMedicalRecords.value = false;
       }
@@ -222,7 +176,6 @@ export const usePatientsStore = defineStore(
         });
         return res.data;
       } catch (error) {
-        console.error("Error uploading file:", error);
         throw error;
       } finally {
         isLoadingMedicalRecords.value = false;
@@ -240,13 +193,11 @@ export const usePatientsStore = defineStore(
           responseType: "blob",
         });
         return res.data;
-      } catch (error) {
-        console.error("Error downloading file:", error);
-        throw error;
+      } finally {
+        return null;
       }
     }
 
-    // === FUNCIONES PARA RECETAS ===
     async function fetchRecipe(recipeId) {
       isLoadingMedicalRecords.value = true;
       try {
@@ -275,10 +226,6 @@ export const usePatientsStore = defineStore(
       } finally {
         isLoadingMedicalRecords.value = false;
       }
-    }
-
-    function clearFullRecord() {
-      fullRecord.value = null;
     }
 
     function clearFullRecord() {
@@ -319,7 +266,7 @@ export const usePatientsStore = defineStore(
       fetchRecipe,
       updateRecipe,
       createRecipe,
-      clearFullRecord,
+      clearFullRecord
     };
   },
   {

--- a/frontend-app/src/stores/patientsStore.js
+++ b/frontend-app/src/stores/patientsStore.js
@@ -175,27 +175,21 @@ export const usePatientsStore = defineStore(
           },
         });
         return res.data;
-      } catch (error) {
-        throw error;
       } finally {
         isLoadingMedicalRecords.value = false;
       }
     }
 
     async function downloadFile(PatientId, type, MedicalRecordId) {
-      try {
-        const res = await instance.get("/files/download", {
-          params: {
-            PatientId,
-            type,
-            MedicalRecordId,
-          },
-          responseType: "blob",
-        });
-        return res.data;
-      } finally {
-        return null;
-      }
+      const res = await instance.get("/files/download", {
+        params: {
+          PatientId,
+          type,
+          MedicalRecordId,
+        },
+        responseType: "blob",
+      });
+      return res.data;
     }
 
     async function fetchRecipe(recipeId) {

--- a/frontend-app/src/tests/components/patientTestComponents/PatientsDataSheetDialog.test.js
+++ b/frontend-app/src/tests/components/patientTestComponents/PatientsDataSheetDialog.test.js
@@ -1,4 +1,3 @@
-// PatientsDataSheetDialog.test.js
 import { describe, it, expect, vi } from "vitest";
 import { mount } from "@vue/test-utils";
 import { createTestingPinia } from "@pinia/testing";
@@ -57,8 +56,6 @@ describe("PatientsDataSheetDialog.vue", () => {
     });
 
     await wrapper.vm.$nextTick();
-    console.log(wrapper.html()); // Útil para depurar visualmente
-
     expect(wrapper.text()).toContain("Ana");
     expect(wrapper.text()).toContain("Pérez");
     expect(wrapper.text()).toContain("2001-01-01");

--- a/frontend-app/src/tests/components/patientTestComponents/PatientsMainDataBox.test.js
+++ b/frontend-app/src/tests/components/patientTestComponents/PatientsMainDataBox.test.js
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
 import { mount } from "@vue/test-utils";
-import ActionButtonSolidIcon from "@components/forms/ActionButtonSolidIcon.vue";
 import PatientMainDataBox from "@components/patientsComponents/PatientMainDataBox.vue";
 
 describe("PatientMainDataBox.vue", () => {

--- a/frontend-app/src/utils/fileAdapter.js
+++ b/frontend-app/src/utils/fileAdapter.js
@@ -1,3 +1,4 @@
+import { Blob } from 'buffer';
 export class FileAdapter {
   constructor(source, options = {}) {
     this.source = source;

--- a/frontend-app/src/utils/isoFormatDate.js
+++ b/frontend-app/src/utils/isoFormatDate.js
@@ -41,10 +41,6 @@ export function isoFormatDate(dateInput) {
   const year = date.getFullYear();
   const month = pad2(date.getMonth() + 1);
   const day = pad2(date.getDate());
-  const hours = pad2(date.getHours());
-  const minutes = pad2(date.getMinutes());
-  const seconds = pad2(date.getSeconds());
-  const milliseconds = date.getMilliseconds();
 
   const iso8601 = date.toISOString();
   const isoDate = `${year}-${month}-${day}`;
@@ -70,22 +66,15 @@ export function isoFormatDate(dateInput) {
  */
 export function formatDate(dateString, options = {}) {
   if (!dateString) return "Fecha no disponible";
-
-  try {
-    const defaultOptions = {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-      ...options,
-    };
-
-    return new Date(dateString).toLocaleDateString("es-ES", defaultOptions);
-  } catch (error) {
-    console.error("Error al formatear fecha:", error);
-    return "Fecha inválida";
-  }
+  const defaultOptions = {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    ...options,
+  };
+  return new Date(dateString).toLocaleDateString("es-ES", defaultOptions);
 }
 
 /**

--- a/frontend-app/src/views/LoginView.vue
+++ b/frontend-app/src/views/LoginView.vue
@@ -3,7 +3,12 @@
     class="flex min-h-screen flex-1 flex-col justify-center items-center px-6 py-12 lg:px-8"
   >
     <div class="sm:mx-auto sm:w-full sm:max-w-sm text-center">
-      <img class="mx-auto" src="/logo-gastro.png" width="250" height="250" />
+      <img
+        class="mx-auto"
+        src="/logo-gastro.png"
+        width="250"
+        height="250"
+      />
       <h2
         class="mt-10 text-2xl font-bold leading-9 tracking-tight text-gray-900"
       >
@@ -11,8 +16,8 @@
       </h2>
     </div>
     <form
-      @submit.prevent="onSubmitLogin"
       class="mt-10 sm:mx-auto sm:w-full sm:max-w-sm space-y-4"
+      @submit.prevent="onSubmitLogin"
     >
       <text-input
         class="mt-2"
@@ -32,13 +37,18 @@
         inputColor="primary-color"
       />
 
-      <div v-if="error !== null" class="text-red-600 text-sm">{{ error }}</div>
+      <div
+        v-if="error !== null"
+        class="text-red-600 text-sm"
+      >
+        {{ error }}
+      </div>
 
       <primary-button
-        @click="onSubmitLogin"
         type="submit"
         :disabled="isLoadingAuthStore || !isFormValid"
         class="w-full flex justify-center"
+        @click="onSubmitLogin"
       >
         <basic-spinner-loading v-if="isLoadingAuthStore" />
         <span v-else>{{ $t("login.login") }}</span>
@@ -48,8 +58,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch } from "vue";
-import { useRouter } from "vue-router";
+import { ref, computed } from "vue";
 import { useAuthStore } from "@/stores/authStore";
 import { useForm } from "vee-validate";
 import { storeToRefs } from "pinia";
@@ -59,7 +68,6 @@ import TextInput from "@components/forms/TextInput.vue";
 import PrimaryButton from "@components/forms/PrimaryButton.vue";
 import BasicSpinnerLoading from "@components/forms/BasicSpinnerLoading.vue";
 
-const router = useRouter();
 const authStore = useAuthStore();
 const { isLoadingAuthStore, error } = storeToRefs(authStore);
 const validationError = ref(false);

--- a/frontend-app/src/views/NavigationView.vue
+++ b/frontend-app/src/views/NavigationView.vue
@@ -1,38 +1,44 @@
 <template>
   <div>
     <!-- Barra lateral y navegación principal de la app -->
-    <TransitionRoot as="template" :show="sidebarOpen">
-      <Dialog class="relative z-50 lg:hidden" @close="sidebarOpen = false">
+    <TransitionRoot
+      as="template"
+      :show="sidebarOpen"
+    >
+      <Dialog
+        class="relative z-50 lg:hidden"
+        @close="sidebarOpen = false"
+      >
         <TransitionChild
           as="template"
           enter="transition-opacity ease-linear duration-300"
-          enter-from="opacity-0"
-          enter-to="opacity-100"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
           leave="transition-opacity ease-linear duration-300"
-          leave-from="opacity-100"
-          leave-to="opacity-0"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
         >
-          <div class="fixed inset-0 bg-gray-900/80" />
+          <div class="fixed inset-0 bg-gray-900/80"></div>
         </TransitionChild>
         <div class="fixed inset-0 flex">
           <TransitionChild
             as="template"
             enter="transition ease-in-out duration-300 transform"
-            enter-from="-translate-x-full"
-            enter-to="translate-x-0"
+            enterFrom="-translate-x-full"
+            enterTo="translate-x-0"
             leave="transition ease-in-out duration-300 transform"
-            leave-from="translate-x-0"
-            leave-to="-translate-x-full"
+            leaveFrom="translate-x-0"
+            leaveTo="-translate-x-full"
           >
             <DialogPanel class="relative mr-16 flex w-full max-w-xs flex-1">
               <TransitionChild
                 as="template"
                 enter="ease-in-out duration-300"
-                enter-from="opacity-0"
-                enter-to="opacity-100"
+                enterFrom="opacity-0"
+                enterTo="opacity-100"
                 leave="ease-in-out duration-300"
-                leave-from="opacity-100"
-                leave-to="opacity-0"
+                leaveFrom="opacity-100"
+                leaveTo="opacity-0"
               >
                 <div
                   class="absolute left-full top-0 flex w-16 justify-center pt-5"
@@ -43,7 +49,10 @@
                     @click="sidebarOpen = false"
                   >
                     <span class="sr-only">Close sidebar</span>
-                    <XMarkIcon class="size-6 text-white" aria-hidden="true" />
+                    <XMarkIcon
+                      class="size-6 text-white"
+                      aria-hidden="true"
+                    />
                   </button>
                 </div>
               </TransitionChild>
@@ -102,10 +111,16 @@
           @click="sidebarOpen = true"
         >
           <span class="sr-only">Open sidebar</span>
-          <Bars3Icon class="size-6" aria-hidden="true" />
+          <Bars3Icon
+            class="size-6"
+            aria-hidden="true"
+          />
         </button>
 
-        <div class="h-6 w-px bg-gray-900/10 lg:hidden" aria-hidden="true" />
+        <div
+          class="h-6 w-px bg-gray-900/10 lg:hidden"
+          aria-hidden="true"
+        ></div>
 
         <div class="flex flex-1 gap-x-4 self-stretch lg:gap-x-6">
           <form
@@ -114,11 +129,11 @@
             method="GET"
           >
             <ComboBoxAutocompleteInputSearchPatient
-              :data="allPatients"
               v-model:currentSelected="currentPatientSelectedId"
-              @update:currentSelected="handlePatientSelection"
+              :data="allPatients"
               class="col-start-1 row-start-1 block w-full bg-white pl-8 text-base text-gray-900 outline-none placeholder:text-gray-400 sm:text-sm/6"
               :placeholder="$t('general.search-patient')"
+              @update:current-selected="handlePatientSelection"
             />
             <MagnifyingGlassIcon
               class="pointer-events-none col-start-1 row-start-1 size-5 self-center text-gray-400"
@@ -134,10 +149,13 @@
             <div
               class="hidden lg:block lg:h-6 lg:w-px lg:bg-gray-900/10"
               aria-hidden="true"
-            />
+            ></div>
 
             <!-- Menú de perfil de usuario -->
-            <Menu as="div" class="relative">
+            <Menu
+              as="div"
+              class="relative"
+            >
               <MenuButton class="-m-1.5 flex items-center p-1.5">
                 <span class="hidden lg:flex lg:items-center">
                   <span class="ml-4 text-sm/6 font-semibold text-gray-900">
@@ -150,12 +168,12 @@
                 </span>
               </MenuButton>
               <transition
-                enter-active-class="transition ease-out duration-100"
-                enter-from-class="transform opacity-0 scale-95"
-                enter-to-class="transform opacity-100 scale-100"
-                leave-active-class="transition ease-in duration-75"
-                leave-from-class="transform opacity-100 scale-100"
-                leave-to-class="transform opacity-0 scale-95"
+                enterActiveClass="transition ease-out duration-100"
+                enterFromClass="transform opacity-0 scale-95"
+                enterToClass="transform opacity-100 scale-100"
+                leaveActiveClass="transition ease-in duration-75"
+                leaveFromClass="transform opacity-100 scale-100"
+                leaveToClass="transform opacity-0 scale-95"
               >
                 <MenuItems
                   class="absolute right-0 z-10 mt-2.5 w-32 origin-top-right rounded-md bg-white py-2 shadow-lg ring-1 ring-gray-900/5 focus:outline-none"
@@ -167,11 +185,11 @@
                   >
                     <button
                       type="button"
-                      @click="item.action()"
                       :class="[
                         active ? 'bg-gray-50' : '',
                         'w-full text-left px-3 py-1 text-sm/6 text-gray-900',
                       ]"
+                      @click="item.action()"
                     >
                       {{ $t(item.name) }}
                     </button>

--- a/frontend-app/src/views/PatientsView.vue
+++ b/frontend-app/src/views/PatientsView.vue
@@ -1,49 +1,48 @@
 <template>
   <div>
-    <div v-if="isLoadingPatientData" class="text-center py-6">
+    <div
+      v-if="isLoadingPatientData"
+      class="text-center py-6"
+    >
       {{ $t("patients.loading-patients-data") }}
     </div>
-    <div v-else class="px-6 py-8 mx-auto grid grid-cols-5 grid-rows-5 gap-5">
-      <panel class="col-span-5">
+    <div
+      v-else
+      class="px-6 py-8 mx-auto grid grid-cols-5 grid-rows-5 gap-5"
+    >
+      <app-panel class="col-span-5">
         <PatientMainDataBox :data="currentPatientSelectedData" />
-      </panel>
-      <panel class="col-span-2 row-span-2 row-start-2">
+      </app-panel>
+      <app-panel class="col-span-2 row-span-2 row-start-2">
         <patient-important-information-box :data="currentPatientSelectedData" />
-      </panel>
-      <panel class="col-span-2 row-span-2 col-start-1 row-start-4">
+      </app-panel>
+      <app-panel class="col-span-2 row-span-2 col-start-1 row-start-4">
         <patient-contact-data-box :data="currentPatientSelectedData" />
-      </panel>
-      <panel class="col-span-3 col-start-3 row-start-2">
+      </app-panel>
+      <app-panel class="col-span-3 col-start-3 row-start-2">
         <patient-data-sheet-box :viewDataSheet="openDataSheetPatientDialog" />
-      </panel>
+      </app-panel>
       <div class="col-span-3 row-span-3 col-start-3 row-start-3">
         <patient-history-log-box
-          :patient-id="currentPatientSelectedId"
+          :patientId="currentPatientSelectedId"
           @view-recipe="openRecipeModal"
         />
       </div>
     </div>
-    <!-- <MedicalRecipePanel
-               v-if="showRecipeModal"
-               :recipe="selectedRecipe"
-               @close="closeRecipeModal"
-          /> -->
   </div>
   <patients-data-sheet-dialog
     v-if="showDataSheetPatientDialog"
-    @close="closeAllPatientDialog"
     :isOpen="showDataSheetPatientDialog"
+    @close="closeAllPatientDialog"
   />
 </template>
 
 <script setup>
 import { usePatientsStore } from "@stores/patientsStore";
 import { usePatientsLogicStore } from "@stores/patientsLogicStore.js";
-import { ref, watch, computed, onMounted, defineAsyncComponent } from "vue";
+import { ref, watch, onMounted } from "vue";
 import { storeToRefs } from "pinia";
-import { isoFormatDate } from "@/utils/isoFormatDate";
-import { formatAgeFromDate } from "@/utils/formatAge";
-import { normalizeGender } from "@/utils/normalizeGender";
+
 
 import PatientContactDataBox from "@components/patientsComponents/PatientContactDataBox.vue";
 import PatientDataSheetBox from "@components/patientsComponents/PatientDataSheetBox.vue";
@@ -52,8 +51,7 @@ import PatientImportantInformationBox from "@components/patientsComponents/Patie
 import PatientMainDataBox from "@components/patientsComponents/PatientMainDataBox.vue";
 
 import PatientsDataSheetDialog from "@components/patientsDialogsComponents/patientsDataSheetDialog.vue";
-import Panel from "@components/forms/Panel.vue";
-import MedicalRecipePanel from "@components/patientsComponents/MedicalRecipePanel.vue";
+import AppPanel from "@components/forms/AppPanel.vue";
 
 const showRecipeModal = ref(false);
 const selectedRecipe = ref(null);
@@ -63,17 +61,10 @@ function openRecipeModal(receta) {
   showRecipeModal.value = true;
 }
 
-function closeRecipeModal() {
-  showRecipeModal.value = false;
-  selectedRecipe.value = null;
-}
-// Store y referencias
-
 const patientsStore = usePatientsStore();
 const {
   currentPatientSelectedId,
   currentPatientSelectedData,
-  currentPatientMedicalRecords,
   isLoadingPatientData,
 } = storeToRefs(patientsStore);
 
@@ -82,45 +73,17 @@ const { showDataSheetPatientDialog } = storeToRefs(patientsLogicStore);
 const { openDataSheetPatientDialog, closeAllPatientDialog } =
   patientsLogicStore;
 
-// Observador para cargar datos cuando cambie el ID
 watch(currentPatientSelectedId, async (newId) => {
   if (newId) {
-    try {
-      // Primero intentamos cargar datos básicos del paciente
-      await patientsStore.fetchPatientData(newId);
-
-      // Luego intentamos cargar registros médicos, pero manejamos el error
-      try {
-        await patientsStore.fetchPatientMedicalRecords(newId);
-      } catch (medicalError) {
-        console.warn("No se pudieron cargar registros médicos:", medicalError);
-        // No hacemos fallar toda la operación por esto
-      }
-    } catch (error) {
-      console.error("Error al cargar datos del paciente:", error);
-    }
+    await patientsStore.fetchPatientData(newId);
+    await patientsStore.fetchPatientMedicalRecords(newId);
   }
 });
 
-// Cargar datos del paciente seleccionado al montar el componente
 onMounted(async () => {
-  // Si ya hay un ID seleccionado, cargar sus datos
   if (currentPatientSelectedId.value) {
-    try {
-      // Cargar datos básicos del paciente
-      await patientsStore.fetchPatientData(currentPatientSelectedId.value);
-
-      // Intentar cargar registros médicos
-      try {
-        await patientsStore.fetchPatientMedicalRecords(
-          currentPatientSelectedId.value,
-        );
-      } catch (medicalError) {
-        console.warn("No se pudieron cargar registros médicos:", medicalError);
-      }
-    } catch (error) {
-      console.error("Error al cargar datos del paciente:", error);
-    }
+    await patientsStore.fetchPatientData(currentPatientSelectedId.value);
+    await patientsStore.fetchPatientMedicalRecords( currentPatientSelectedId.value);
   }
 });
 </script>

--- a/frontend-app/src/views/ProfileView.vue
+++ b/frontend-app/src/views/ProfileView.vue
@@ -35,18 +35,26 @@
         <h2 class="mt-4 text-2xl font-semibold text-gray-800">
           {{ fullName }}
         </h2>
-        <p class="text-gray-500">{{ user.email }}</p>
+        <p class="text-gray-500">
+          {{ user.email }}
+        </p>
 
         <!-- Datos extra: rol y fecha de creación -->
         <div
           class="mt-6 w-full grid grid-cols-1 sm:grid-cols-2 gap-4 text-center"
         >
           <div>
-            <p class="text-sm text-gray-400">Rol</p>
-            <p class="mt-1 font-medium text-gray-700">{{ user.role }}</p>
+            <p class="text-sm text-gray-400">
+              Rol
+            </p>
+            <p class="mt-1 font-medium text-gray-700">
+              {{ user.role }}
+            </p>
           </div>
           <div>
-            <p class="text-sm text-gray-400">Creado el</p>
+            <p class="text-sm text-gray-400">
+              Creado el
+            </p>
             <p class="mt-1 font-medium text-gray-700">
               {{ formattedCreatedAt }}
             </p>

--- a/frontend-app/yarn.lock
+++ b/frontend-app/yarn.lock
@@ -45,7 +45,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz"
   integrity sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==
 
-"@babel/core@^7.23.0":
+"@babel/core@^7.0.0", "@babel/core@^7.0.0-0", "@babel/core@^7.11.0", "@babel/core@^7.23.0":
   version "7.26.10"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz"
   integrity sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==
@@ -64,6 +64,15 @@
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
     json5 "^2.2.3"
+    semver "^6.3.1"
+
+"@babel/eslint-parser@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.28.0.tgz"
+  integrity sha512-N4ntErOlKvcbTt01rr5wj3y55xnIdx1ymrfIr8C2WnM1Y9glFgWaGDEULJIazOX3XM9NRzhfJ6zZnQ1sBNWU+w==
+  dependencies:
+    "@nicolo-ribaudo/eslint-scope-5-internals" "5.1.1-v1"
+    eslint-visitor-keys "^2.1.0"
     semver "^6.3.1"
 
 "@babel/generator@^7.26.10", "@babel/generator@^7.27.0":
@@ -300,140 +309,20 @@
     "@csstools/color-helpers" "^5.0.2"
     "@csstools/css-calc" "^2.1.4"
 
-"@csstools/css-parser-algorithms@^3.0.4":
+"@csstools/css-parser-algorithms@^3.0.4", "@csstools/css-parser-algorithms@^3.0.5":
   version "3.0.5"
   resolved "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz"
   integrity sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==
 
-"@csstools/css-tokenizer@^3.0.3":
+"@csstools/css-tokenizer@^3.0.3", "@csstools/css-tokenizer@^3.0.4":
   version "3.0.4"
   resolved "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz"
   integrity sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==
 
-"@esbuild/aix-ppc64@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz#b87036f644f572efb2b3c75746c97d1d2d87ace8"
-  integrity sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==
-
-"@esbuild/android-arm64@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.2.tgz#5ca7dc20a18f18960ad8d5e6ef5cf7b0a256e196"
-  integrity sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==
-
-"@esbuild/android-arm@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.2.tgz#3c49f607b7082cde70c6ce0c011c362c57a194ee"
-  integrity sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==
-
-"@esbuild/android-x64@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.2.tgz#8a00147780016aff59e04f1036e7cb1b683859e2"
-  integrity sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==
-
 "@esbuild/darwin-arm64@0.25.2":
   version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.2.tgz#486efe7599a8d90a27780f2bb0318d9a85c6c423"
+  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.2.tgz"
   integrity sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==
-
-"@esbuild/darwin-x64@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.2.tgz#95ee222aacf668c7a4f3d7ee87b3240a51baf374"
-  integrity sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==
-
-"@esbuild/freebsd-arm64@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.2.tgz#67efceda8554b6fc6a43476feba068fb37fa2ef6"
-  integrity sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==
-
-"@esbuild/freebsd-x64@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.2.tgz#88a9d7ecdd3adadbfe5227c2122d24816959b809"
-  integrity sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==
-
-"@esbuild/linux-arm64@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.2.tgz#87be1099b2bbe61282333b084737d46bc8308058"
-  integrity sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==
-
-"@esbuild/linux-arm@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.2.tgz#72a285b0fe64496e191fcad222185d7bf9f816f6"
-  integrity sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==
-
-"@esbuild/linux-ia32@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.2.tgz#337a87a4c4dd48a832baed5cbb022be20809d737"
-  integrity sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==
-
-"@esbuild/linux-loong64@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.2.tgz#1b81aa77103d6b8a8cfa7c094ed3d25c7579ba2a"
-  integrity sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==
-
-"@esbuild/linux-mips64el@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.2.tgz#afbe380b6992e7459bf7c2c3b9556633b2e47f30"
-  integrity sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==
-
-"@esbuild/linux-ppc64@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.2.tgz#6bf8695cab8a2b135cca1aa555226dc932d52067"
-  integrity sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==
-
-"@esbuild/linux-riscv64@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.2.tgz#43c2d67a1a39199fb06ba978aebb44992d7becc3"
-  integrity sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==
-
-"@esbuild/linux-s390x@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.2.tgz#419e25737ec815c6dce2cd20d026e347cbb7a602"
-  integrity sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==
-
-"@esbuild/linux-x64@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.2.tgz"
-  integrity sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==
-
-"@esbuild/netbsd-arm64@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.2.tgz#744affd3b8d8236b08c5210d828b0698a62c58ac"
-  integrity sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==
-
-"@esbuild/netbsd-x64@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.2.tgz#dbbe7521fd6d7352f34328d676af923fc0f8a78f"
-  integrity sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==
-
-"@esbuild/openbsd-arm64@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.2.tgz#f9caf987e3e0570500832b487ce3039ca648ce9f"
-  integrity sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==
-
-"@esbuild/openbsd-x64@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.2.tgz#d2bb6a0f8ffea7b394bb43dfccbb07cabd89f768"
-  integrity sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw==
-
-"@esbuild/sunos-x64@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.2.tgz#49b437ed63fe333b92137b7a0c65a65852031afb"
-  integrity sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==
-
-"@esbuild/win32-arm64@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.2.tgz#081424168463c7d6c7fb78f631aede0c104373cf"
-  integrity sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q==
-
-"@esbuild/win32-ia32@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.2.tgz#3f9e87143ddd003133d21384944a6c6cadf9693f"
-  integrity sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==
-
-"@esbuild/win32-x64@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.2.tgz#839f72c2decd378f86b8f525e1979a97b920c67d"
-  integrity sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.7.0"
@@ -483,6 +372,11 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@eslint/js@^9.34.0":
+  version "9.34.0"
+  resolved "https://registry.npmjs.org/@eslint/js/-/js-9.34.0.tgz"
+  integrity sha512-EoyvqQnBNsV1CWaEJ559rxXL4c8V92gxirbawSmVUOWXlsRxxQXl6LmCpdUblgxgSkDIqKnhzba2SjRTI/A5Rw==
+
 "@eslint/js@9.32.0":
   version "9.32.0"
   resolved "https://registry.npmjs.org/@eslint/js/-/js-9.32.0.tgz"
@@ -501,7 +395,7 @@
     "@eslint/core" "^0.15.1"
     levn "^0.4.1"
 
-"@fullcalendar/core@^6.1.17":
+"@fullcalendar/core@^6.1.17", "@fullcalendar/core@~6.1.17":
   version "6.1.17"
   resolved "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.17.tgz"
   integrity sha512-0W7lnIrv18ruJ5zeWBeNZXO8qCWlzxDdp9COFEsZnyNjiEhUVnrW/dPbjRKYpL0edGG0/Lhs0ghp1z/5ekt8ZA==
@@ -623,6 +517,13 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
+  version "5.1.1-v1"
+  resolved "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz"
+  integrity sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==
+  dependencies:
+    eslint-scope "5.1.1"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
@@ -631,7 +532,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -694,7 +595,7 @@
 
 "@playwright/experimental-ct-core@1.55.0":
   version "1.55.0"
-  resolved "https://registry.yarnpkg.com/@playwright/experimental-ct-core/-/experimental-ct-core-1.55.0.tgz#8c338f4db74374763a4b00df2927c5eb7a18623a"
+  resolved "https://registry.npmjs.org/@playwright/experimental-ct-core/-/experimental-ct-core-1.55.0.tgz"
   integrity sha512-8HRI8Envzgv3bVr6CrKCW3NxFR3dvXaE10OACkfs50GiTn5t4m31UJ3wDpFAgzxZvXPoyLfG3mLG16YbpWS5Ww==
   dependencies:
     playwright "1.55.0"
@@ -703,7 +604,7 @@
 
 "@playwright/experimental-ct-vue@^1.55.0":
   version "1.55.0"
-  resolved "https://registry.yarnpkg.com/@playwright/experimental-ct-vue/-/experimental-ct-vue-1.55.0.tgz#813009c4571622395aaa19b7a48bd8edfa46ceb1"
+  resolved "https://registry.npmjs.org/@playwright/experimental-ct-vue/-/experimental-ct-vue-1.55.0.tgz"
   integrity sha512-971Ckf1xX/9CDXAz8kNNLJRKyve8aIbqJpJULqCr46cP80PrJbp7yDG9CIb7aRxwmvrheZagTMrkc+Zvw49b2g==
   dependencies:
     "@playwright/experimental-ct-core" "1.55.0"
@@ -711,7 +612,7 @@
 
 "@playwright/test@^1.55.0":
   version "1.55.0"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.55.0.tgz#080fa6d9ee6d749ff523b1c18259572d0268b963"
+  resolved "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz"
   integrity sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==
   dependencies:
     playwright "1.55.0"
@@ -730,205 +631,10 @@
     estree-walker "^2.0.2"
     picomatch "^4.0.2"
 
-"@rollup/rollup-android-arm-eabi@4.39.0":
-  version "4.39.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.39.0.tgz#1d8cc5dd3d8ffe569d8f7f67a45c7909828a0f66"
-  integrity sha512-lGVys55Qb00Wvh8DMAocp5kIcaNzEFTmGhfFd88LfaogYTRKrdxgtlO5H6S49v2Nd8R2C6wLOal0qv6/kCkOwA==
-
-"@rollup/rollup-android-arm-eabi@4.47.1":
-  version "4.47.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.47.1.tgz#6e236cd2fd29bb01a300ad4ff6ed0f1a17550e69"
-  integrity sha512-lTahKRJip0knffA/GTNFJMrToD+CM+JJ+Qt5kjzBK/sFQ0EWqfKW3AYQSlZXN98tX0lx66083U9JYIMioMMK7g==
-
-"@rollup/rollup-android-arm64@4.39.0":
-  version "4.39.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.39.0.tgz#9c136034d3d9ed29d0b138c74dd63c5744507fca"
-  integrity sha512-It9+M1zE31KWfqh/0cJLrrsCPiF72PoJjIChLX+rEcujVRCb4NLQ5QzFkzIZW8Kn8FTbvGQBY5TkKBau3S8cCQ==
-
-"@rollup/rollup-android-arm64@4.47.1":
-  version "4.47.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.47.1.tgz#808f2c9c7e68161add613ebcb0eac5a058a0df3c"
-  integrity sha512-uqxkb3RJLzlBbh/bbNQ4r7YpSZnjgMgyoEOY7Fy6GCbelkDSAzeiogxMG9TfLsBbqmGsdDObo3mzGqa8hps4MA==
-
 "@rollup/rollup-darwin-arm64@4.39.0":
   version "4.39.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.39.0.tgz#830d07794d6a407c12b484b8cf71affd4d3800a6"
+  resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.39.0.tgz"
   integrity sha512-lXQnhpFDOKDXiGxsU9/l8UEGGM65comrQuZ+lDcGUx+9YQ9dKpF3rSEGepyeR5AHZ0b5RgiligsBhWZfSSQh8Q==
-
-"@rollup/rollup-darwin-arm64@4.47.1":
-  version "4.47.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.47.1.tgz#fa41e413c8e73d61039d6375b234595f24b1e5e3"
-  integrity sha512-tV6reObmxBDS4DDyLzTDIpymthNlxrLBGAoQx6m2a7eifSNEZdkXQl1PE4ZjCkEDPVgNXSzND/k9AQ3mC4IOEQ==
-
-"@rollup/rollup-darwin-x64@4.39.0":
-  version "4.39.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.39.0.tgz#b26f0f47005c1fa5419a880f323ed509dc8d885c"
-  integrity sha512-mKXpNZLvtEbgu6WCkNij7CGycdw9cJi2k9v0noMb++Vab12GZjFgUXD69ilAbBh034Zwn95c2PNSz9xM7KYEAQ==
-
-"@rollup/rollup-darwin-x64@4.47.1":
-  version "4.47.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.47.1.tgz#9aac64e886435493f2e3a0aa5e4aad098a90814c"
-  integrity sha512-XuJRPTnMk1lwsSnS3vYyVMu4x/+WIw1MMSiqj5C4j3QOWsMzbJEK90zG+SWV1h0B1ABGCQ0UZUjti+TQK35uHQ==
-
-"@rollup/rollup-freebsd-arm64@4.39.0":
-  version "4.39.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.39.0.tgz#2b60c81ac01ff7d1bc8df66aee7808b6690c6d19"
-  integrity sha512-jivRRlh2Lod/KvDZx2zUR+I4iBfHcu2V/BA2vasUtdtTN2Uk3jfcZczLa81ESHZHPHy4ih3T/W5rPFZ/hX7RtQ==
-
-"@rollup/rollup-freebsd-arm64@4.47.1":
-  version "4.47.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.47.1.tgz#9fc804264f7b7a7cdad3747950299f990163be1f"
-  integrity sha512-79BAm8Ag/tmJ5asCqgOXsb3WY28Rdd5Lxj8ONiQzWzy9LvWORd5qVuOnjlqiWWZJw+dWewEktZb5yiM1DLLaHw==
-
-"@rollup/rollup-freebsd-x64@4.39.0":
-  version "4.39.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.39.0.tgz#4826af30f4d933d82221289068846c9629cc628c"
-  integrity sha512-8RXIWvYIRK9nO+bhVz8DwLBepcptw633gv/QT4015CpJ0Ht8punmoHU/DuEd3iw9Hr8UwUV+t+VNNuZIWYeY7Q==
-
-"@rollup/rollup-freebsd-x64@4.47.1":
-  version "4.47.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.47.1.tgz#933feaff864feb03bbbcd0c18ea351ade957cf79"
-  integrity sha512-OQ2/ZDGzdOOlyfqBiip0ZX/jVFekzYrGtUsqAfLDbWy0jh1PUU18+jYp8UMpqhly5ltEqotc2miLngf9FPSWIA==
-
-"@rollup/rollup-linux-arm-gnueabihf@4.39.0":
-  version "4.39.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.39.0.tgz#a1f4f963d5dcc9e5575c7acf9911824806436bf7"
-  integrity sha512-mz5POx5Zu58f2xAG5RaRRhp3IZDK7zXGk5sdEDj4o96HeaXhlUwmLFzNlc4hCQi5sGdR12VDgEUqVSHer0lI9g==
-
-"@rollup/rollup-linux-arm-gnueabihf@4.47.1":
-  version "4.47.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.47.1.tgz#02915e6b2c55fe5961c27404aba2d9c8ef48ac6c"
-  integrity sha512-HZZBXJL1udxlCVvoVadstgiU26seKkHbbAMLg7680gAcMnRNP9SAwTMVet02ANA94kXEI2VhBnXs4e5nf7KG2A==
-
-"@rollup/rollup-linux-arm-musleabihf@4.39.0":
-  version "4.39.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.39.0.tgz#e924b0a8b7c400089146f6278446e6b398b75a06"
-  integrity sha512-+YDwhM6gUAyakl0CD+bMFpdmwIoRDzZYaTWV3SDRBGkMU/VpIBYXXEvkEcTagw/7VVkL2vA29zU4UVy1mP0/Yw==
-
-"@rollup/rollup-linux-arm-musleabihf@4.47.1":
-  version "4.47.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.47.1.tgz#1afef33191b26e76ae7f0d0dc767efc6be1285ce"
-  integrity sha512-sZ5p2I9UA7T950JmuZ3pgdKA6+RTBr+0FpK427ExW0t7n+QwYOcmDTK/aRlzoBrWyTpJNlS3kacgSlSTUg6P/Q==
-
-"@rollup/rollup-linux-arm64-gnu@4.39.0":
-  version "4.39.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.39.0.tgz#cb43303274ec9a716f4440b01ab4e20c23aebe20"
-  integrity sha512-EKf7iF7aK36eEChvlgxGnk7pdJfzfQbNvGV/+l98iiMwU23MwvmV0Ty3pJ0p5WQfm3JRHOytSIqD9LB7Bq7xdQ==
-
-"@rollup/rollup-linux-arm64-gnu@4.47.1":
-  version "4.47.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.47.1.tgz#6e7f38fb99d14143de3ce33204e6cd61e1c2c780"
-  integrity sha512-3hBFoqPyU89Dyf1mQRXCdpc6qC6At3LV6jbbIOZd72jcx7xNk3aAp+EjzAtN6sDlmHFzsDJN5yeUySvorWeRXA==
-
-"@rollup/rollup-linux-arm64-musl@4.39.0":
-  version "4.39.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.39.0.tgz#531c92533ce3d167f2111bfcd2aa1a2041266987"
-  integrity sha512-vYanR6MtqC7Z2SNr8gzVnzUul09Wi1kZqJaek3KcIlI/wq5Xtq4ZPIZ0Mr/st/sv/NnaPwy/D4yXg5x0B3aUUA==
-
-"@rollup/rollup-linux-arm64-musl@4.47.1":
-  version "4.47.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.47.1.tgz#25ab09f14bbcba85a604bcee2962d2486db90794"
-  integrity sha512-49J4FnMHfGodJWPw73Ve+/hsPjZgcXQGkmqBGZFvltzBKRS+cvMiWNLadOMXKGnYRhs1ToTGM0sItKISoSGUNA==
-
-"@rollup/rollup-linux-loongarch64-gnu@4.39.0":
-  version "4.39.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.39.0.tgz#53403889755d0c37c92650aad016d5b06c1b061a"
-  integrity sha512-NMRUT40+h0FBa5fb+cpxtZoGAggRem16ocVKIv5gDB5uLDgBIwrIsXlGqYbLwW8YyO3WVTk1FkFDjMETYlDqiw==
-
-"@rollup/rollup-linux-loongarch64-gnu@4.47.1":
-  version "4.47.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.47.1.tgz#d3e3a3fd61e21b2753094391dee9b515a2bc9ecd"
-  integrity sha512-4yYU8p7AneEpQkRX03pbpLmE21z5JNys16F1BZBZg5fP9rIlb0TkeQjn5du5w4agConCCEoYIG57sNxjryHEGg==
-
-"@rollup/rollup-linux-powerpc64le-gnu@4.39.0":
-  version "4.39.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.39.0.tgz#f669f162e29094c819c509e99dbeced58fc708f9"
-  integrity sha512-0pCNnmxgduJ3YRt+D+kJ6Ai/r+TaePu9ZLENl+ZDV/CdVczXl95CbIiwwswu4L+K7uOIGf6tMo2vm8uadRaICQ==
-
-"@rollup/rollup-linux-ppc64-gnu@4.47.1":
-  version "4.47.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.47.1.tgz#6b44445e2bd5866692010de241bf18d2ae8b0cb8"
-  integrity sha512-fAiq+J28l2YMWgC39jz/zPi2jqc0y3GSRo1yyxlBHt6UN0yYgnegHSRPa3pnHS5amT/efXQrm0ug5+aNEu9UuQ==
-
-"@rollup/rollup-linux-riscv64-gnu@4.39.0":
-  version "4.39.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.39.0.tgz#4bab37353b11bcda5a74ca11b99dea929657fd5f"
-  integrity sha512-t7j5Zhr7S4bBtksT73bO6c3Qa2AV/HqiGlj9+KB3gNF5upcVkx+HLgxTm8DK4OkzsOYqbdqbLKwvGMhylJCPhQ==
-
-"@rollup/rollup-linux-riscv64-gnu@4.47.1":
-  version "4.47.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.47.1.tgz#3ff412d20d3b157e6aadabf84788e8c5cb221ba7"
-  integrity sha512-daoT0PMENNdjVYYU9xec30Y2prb1AbEIbb64sqkcQcSaR0zYuKkoPuhIztfxuqN82KYCKKrj+tQe4Gi7OSm1ow==
-
-"@rollup/rollup-linux-riscv64-musl@4.39.0":
-  version "4.39.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.39.0.tgz#4d66be1ce3cfd40a7910eb34dddc7cbd4c2dd2a5"
-  integrity sha512-m6cwI86IvQ7M93MQ2RF5SP8tUjD39Y7rjb1qjHgYh28uAPVU8+k/xYWvxRO3/tBN2pZkSMa5RjnPuUIbrwVxeA==
-
-"@rollup/rollup-linux-riscv64-musl@4.47.1":
-  version "4.47.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.47.1.tgz#104f451497d53d82a49c6d08c13c59f5f30eed57"
-  integrity sha512-JNyXaAhWtdzfXu5pUcHAuNwGQKevR+6z/poYQKVW+pLaYOj9G1meYc57/1Xv2u4uTxfu9qEWmNTjv/H/EpAisw==
-
-"@rollup/rollup-linux-s390x-gnu@4.39.0":
-  version "4.39.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.39.0.tgz#7181c329395ed53340a0c59678ad304a99627f6d"
-  integrity sha512-iRDJd2ebMunnk2rsSBYlsptCyuINvxUfGwOUldjv5M4tpa93K8tFMeYGpNk2+Nxl+OBJnBzy2/JCscGeO507kA==
-
-"@rollup/rollup-linux-s390x-gnu@4.47.1":
-  version "4.47.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.47.1.tgz#d04de7b21d181f30750760cb3553946306506172"
-  integrity sha512-U/CHbqKSwEQyZXjCpY43/GLYcTVKEXeRHw0rMBJP7fP3x6WpYG4LTJWR3ic6TeYKX6ZK7mrhltP4ppolyVhLVQ==
-
-"@rollup/rollup-linux-x64-gnu@4.39.0":
-  version "4.39.0"
-  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.39.0.tgz"
-  integrity sha512-t9jqYw27R6Lx0XKfEFe5vUeEJ5pF3SGIM6gTfONSMb7DuG6z6wfj2yjcoZxHg129veTqU7+wOhY6GX8wmf90dA==
-
-"@rollup/rollup-linux-x64-gnu@4.47.1":
-  version "4.47.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.47.1.tgz#a6ba88ff7480940a435b1e67ddbb3f207a7ae02f"
-  integrity sha512-uTLEakjxOTElfeZIGWkC34u2auLHB1AYS6wBjPGI00bWdxdLcCzK5awjs25YXpqB9lS8S0vbO0t9ZcBeNibA7g==
-
-"@rollup/rollup-linux-x64-musl@4.39.0":
-  version "4.39.0"
-  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.39.0.tgz"
-  integrity sha512-ThFdkrFDP55AIsIZDKSBWEt/JcWlCzydbZHinZ0F/r1h83qbGeenCt/G/wG2O0reuENDD2tawfAj2s8VK7Bugg==
-
-"@rollup/rollup-linux-x64-musl@4.47.1":
-  version "4.47.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.47.1.tgz#c912c8ffa0c242ed3175cd91cdeaef98109afa54"
-  integrity sha512-Ft+d/9DXs30BK7CHCTX11FtQGHUdpNDLJW0HHLign4lgMgBcPFN3NkdIXhC5r9iwsMwYreBBc4Rho5ieOmKNVQ==
-
-"@rollup/rollup-win32-arm64-msvc@4.39.0":
-  version "4.39.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.39.0.tgz#3a3f421f5ce9bd99ed20ce1660cce7cee3e9f199"
-  integrity sha512-jDrLm6yUtbOg2TYB3sBF3acUnAwsIksEYjLeHL+TJv9jg+TmTwdyjnDex27jqEMakNKf3RwwPahDIt7QXCSqRQ==
-
-"@rollup/rollup-win32-arm64-msvc@4.47.1":
-  version "4.47.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.47.1.tgz#ca5eaae89443554b461bb359112a056528cfdac0"
-  integrity sha512-N9X5WqGYzZnjGAFsKSfYFtAShYjwOmFJoWbLg3dYixZOZqU7hdMq+/xyS14zKLhFhZDhP9VfkzQnsdk0ZDS9IA==
-
-"@rollup/rollup-win32-ia32-msvc@4.39.0":
-  version "4.39.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.39.0.tgz#a44972d5cdd484dfd9cf3705a884bf0c2b7785a7"
-  integrity sha512-6w9uMuza+LbLCVoNKL5FSLE7yvYkq9laSd09bwS0tMjkwXrmib/4KmoJcrKhLWHvw19mwU+33ndC69T7weNNjQ==
-
-"@rollup/rollup-win32-ia32-msvc@4.47.1":
-  version "4.47.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.47.1.tgz#34e76172515fb4b374eb990d59f54faff938246e"
-  integrity sha512-O+KcfeCORZADEY8oQJk4HK8wtEOCRE4MdOkb8qGZQNun3jzmj2nmhV/B/ZaaZOkPmJyvm/gW9n0gsB4eRa1eiQ==
-
-"@rollup/rollup-win32-x64-msvc@4.39.0":
-  version "4.39.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.39.0.tgz#bfe0214e163f70c4fec1c8f7bb8ce266f4c05b7e"
-  integrity sha512-yAkUOkIKZlK5dl7u6dg897doBgLXmUHhIINM2c+sND3DZwnrdQkkSiDh7N75Ll4mM4dxSkYfXqU9fW3lLkMFug==
-
-"@rollup/rollup-win32-x64-msvc@4.47.1":
-  version "4.47.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.47.1.tgz#e5e0a0bae2c9d4858cc9b8dc508b2e10d7f0df8b"
-  integrity sha512-CpKnYa8eHthJa3c+C38v/E+/KZyF1Jdh2Cz3DyKZqEWYgrM1IHFArXNWvBLPQCKUEsAqqKX27tTqVEFbDNUcOA==
 
 "@sec-ant/readable-stream@^0.4.1":
   version "0.4.1"
@@ -997,25 +703,20 @@
   resolved "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz"
   integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
-"@types/estree@1.0.7", "@types/estree@^1.0.0", "@types/estree@^1.0.6":
+"@types/estree@^1.0.0", "@types/estree@^1.0.6", "@types/estree@1.0.7":
   version "1.0.7"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz"
   integrity sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==
-
-"@types/estree@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
-  integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
 
 "@types/json-schema@^7.0.15":
   version "7.0.15"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/node@^24.3.0":
-  version "24.3.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.3.0.tgz#89b09f45cb9a8ee69466f18ee5864e4c3eb84dec"
-  integrity sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==
+"@types/node@^18.0.0 || ^20.0.0 || >=22.0.0", "@types/node@^24.3.0":
+  version "24.3.1"
+  resolved "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz"
+  integrity sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==
   dependencies:
     undici-types "~7.10.0"
 
@@ -1027,12 +728,7 @@
     type-fest "^4.8.3"
     vee-validate "4.15.0"
 
-"@vitejs/plugin-vue@^5.2.0":
-  version "5.2.4"
-  resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz#9e8a512eb174bfc2a333ba959bbf9de428d89ad8"
-  integrity sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==
-
-"@vitejs/plugin-vue@^5.2.1":
+"@vitejs/plugin-vue@^5.2.0", "@vitejs/plugin-vue@^5.2.1":
   version "5.2.3"
   resolved "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.3.tgz"
   integrity sha512-IYSLEQj4LgZZuoVpdSUCw3dIynTWQgPlaRP6iAvMle4My0HdYwr5g5wQAfwOeHQBmYwEkqF70nRpSilr6PoUDg==
@@ -1057,7 +753,7 @@
     estree-walker "^3.0.3"
     magic-string "^0.30.17"
 
-"@vitest/pretty-format@3.2.4", "@vitest/pretty-format@^3.2.4":
+"@vitest/pretty-format@^3.2.4", "@vitest/pretty-format@3.2.4":
   version "3.2.4"
   resolved "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz"
   integrity sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==
@@ -1153,7 +849,7 @@
     estree-walker "^2.0.2"
     source-map-js "^1.2.0"
 
-"@vue/compiler-dom@3.5.13", "@vue/compiler-dom@^3.3.4":
+"@vue/compiler-dom@^3.3.4", "@vue/compiler-dom@3.5.13":
   version "3.5.13"
   resolved "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz"
   integrity sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==
@@ -1161,18 +857,7 @@
     "@vue/compiler-core" "3.5.13"
     "@vue/shared" "3.5.13"
 
-"@vue/compiler-sfc@2.7.16":
-  version "2.7.16"
-  resolved "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.16.tgz"
-  integrity sha512-KWhJ9k5nXuNtygPU7+t1rX6baZeqOYLEforUPjgNDBnLicfHCoi48H87Q8XyLZOrNNsmhuwKqtpDQWjEFe6Ekg==
-  dependencies:
-    "@babel/parser" "^7.23.5"
-    postcss "^8.4.14"
-    source-map "^0.6.1"
-  optionalDependencies:
-    prettier "^1.18.2 || ^2.0.0"
-
-"@vue/compiler-sfc@3.5.13", "@vue/compiler-sfc@^3.5.13":
+"@vue/compiler-sfc@^3.5.13", "@vue/compiler-sfc@>= 3", "@vue/compiler-sfc@3.5.13":
   version "3.5.13"
   resolved "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz"
   integrity sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==
@@ -1187,6 +872,17 @@
     postcss "^8.4.48"
     source-map-js "^1.2.0"
 
+"@vue/compiler-sfc@2.7.16":
+  version "2.7.16"
+  resolved "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.16.tgz"
+  integrity sha512-KWhJ9k5nXuNtygPU7+t1rX6baZeqOYLEforUPjgNDBnLicfHCoi48H87Q8XyLZOrNNsmhuwKqtpDQWjEFe6Ekg==
+  dependencies:
+    "@babel/parser" "^7.23.5"
+    postcss "^8.4.14"
+    source-map "^0.6.1"
+  optionalDependencies:
+    prettier "^1.18.2 || ^2.0.0"
+
 "@vue/compiler-ssr@3.5.13":
   version "3.5.13"
   resolved "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz"
@@ -1195,7 +891,12 @@
     "@vue/compiler-dom" "3.5.13"
     "@vue/shared" "3.5.13"
 
-"@vue/devtools-api@^6.5.0", "@vue/devtools-api@^6.6.4":
+"@vue/devtools-api@^6.5.0":
+  version "6.6.4"
+  resolved "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz"
+  integrity sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==
+
+"@vue/devtools-api@^6.6.4":
   version "6.6.4"
   resolved "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz"
   integrity sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==
@@ -1280,7 +981,7 @@
     "@vue/compiler-ssr" "3.5.13"
     "@vue/shared" "3.5.13"
 
-"@vue/shared@3.5.13", "@vue/shared@^3.5.13":
+"@vue/shared@^3.5.13", "@vue/shared@3.5.13":
   version "3.5.13"
   resolved "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz"
   integrity sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==
@@ -1303,7 +1004,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.14.0, acorn@^8.14.1, acorn@^8.15.0:
+"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.14.0, acorn@^8.14.1, acorn@^8.15.0:
   version "8.15.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
@@ -1468,7 +1169,7 @@ braces@^3.0.3, braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0, browserslist@^4.24.4:
+browserslist@^4.24.0, browserslist@^4.24.4, "browserslist@>= 4.21.0":
   version "4.24.4"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz"
   integrity sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==
@@ -1721,7 +1422,7 @@ dayspan@^0.12.2:
   resolved "https://registry.npmjs.org/dayspan/-/dayspan-0.12.5.tgz"
   integrity sha512-/IkvULBqTRJjUnmKcu3nAGpo04mIszC+ua1ItZadNRxfMKzplmxEljHytOpHdOyl6GF3V7de8oxgep7emeivNA==
 
-debug@4, debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.7, debug@^4.4.1:
+debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.7, debug@^4.4.0, debug@^4.4.1, debug@4:
   version "4.4.1"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz"
   integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
@@ -1995,7 +1696,7 @@ escape-string-regexp@^5.0.0:
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz"
   integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
 
-eslint-config-prettier@^10.0.1:
+eslint-config-prettier@^10.0.1, "eslint-config-prettier@>= 7.0.0 <10.0.0 || >=10.1.0":
   version "10.1.8"
   resolved "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz"
   integrity sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==
@@ -2008,7 +1709,7 @@ eslint-plugin-prettier@^5.2.2:
     prettier-linter-helpers "^1.0.0"
     synckit "^0.11.7"
 
-eslint-plugin-vue@^10.3.0:
+eslint-plugin-vue@^10.4.0:
   version "10.4.0"
   resolved "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.4.0.tgz"
   integrity sha512-K6tP0dW8FJVZLQxa2S7LcE1lLw3X8VvB3t887Q6CLrFVxHYBXGANbXvwNzYIu6Ughx1bSJ5BDT0YB3ybPT39lw==
@@ -2020,6 +1721,14 @@ eslint-plugin-vue@^10.3.0:
     semver "^7.6.3"
     xml-name-validator "^4.0.0"
 
+eslint-scope@^8.2.0:
+  version "8.4.0"
+  resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz"
+  integrity sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^5.2.0"
+
 eslint-scope@^8.4.0:
   version "8.4.0"
   resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz"
@@ -2028,17 +1737,35 @@ eslint-scope@^8.4.0:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
 
+eslint-scope@5.1.1:
+  version "5.1.1"
+  resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^4.1.1"
+
+eslint-visitor-keys@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz"
+  integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
+
 eslint-visitor-keys@^3.4.3:
   version "3.4.3"
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
+
+eslint-visitor-keys@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz"
+  integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
 
 eslint-visitor-keys@^4.2.1:
   version "4.2.1"
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz"
   integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
 
-eslint@^9.31.0:
+"eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^7.5.0 || ^8.0.0 || ^9.0.0", "eslint@^8.57.0 || ^9.0.0", eslint@^9.31.0, "eslint@>= 8.21.0", eslint@>=7.0.0, eslint@>=8.0.0:
   version "9.32.0"
   resolved "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz"
   integrity sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==
@@ -2079,7 +1806,7 @@ eslint@^9.31.0:
     natural-compare "^1.4.0"
     optionator "^0.9.3"
 
-espree@^10.0.1, espree@^10.4.0:
+espree@^10.0.1, espree@^10.3.0, espree@^10.4.0:
   version "10.4.0"
   resolved "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz"
   integrity sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==
@@ -2088,7 +1815,7 @@ espree@^10.0.1, espree@^10.4.0:
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^4.2.1"
 
-esquery@^1.5.0:
+esquery@^1.5.0, esquery@^1.6.0:
   version "1.6.0"
   resolved "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz"
   integrity sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==
@@ -2102,7 +1829,17 @@ esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
-estraverse@^5.1.0, estraverse@^5.2.0:
+estraverse@^4.1.1:
+  version "4.3.0"
+  resolved "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz"
+  integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
+
+estraverse@^5.1.0:
+  version "5.3.0"
+  resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
+  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
+
+estraverse@^5.2.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
@@ -2292,16 +2029,6 @@ fs-extra@^11.2.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fsevents@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
-  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
-
-fsevents@~2.3.2, fsevents@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -2361,7 +2088,7 @@ giget@^2.0.0:
     nypm "^0.6.0"
     pathe "^2.0.3"
 
-glob-parent@^5.1.2, glob-parent@~5.1.2:
+glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -2374,6 +2101,13 @@ glob-parent@^6.0.2:
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
+
+glob-parent@~5.1.2:
+  version "5.1.2"
+  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
+  dependencies:
+    is-glob "^4.0.1"
 
 glob@^10.3.10, glob@^10.4.2:
   version "10.4.5"
@@ -2741,15 +2475,15 @@ jackspeak@^3.1.2:
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
 
+jiti@*, jiti@^2.4.2, jiti@>=1.21.0:
+  version "2.4.2"
+  resolved "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz"
+  integrity sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==
+
 jiti@^1.21.6:
   version "1.21.7"
   resolved "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz"
   integrity sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==
-
-jiti@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz"
-  integrity sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==
 
 js-beautify@^1.14.9:
   version "1.15.4"
@@ -2784,7 +2518,7 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-jsdom@^26.1.0:
+jsdom@*, jsdom@^26.1.0:
   version "26.1.0"
   resolved "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz"
   integrity sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==
@@ -2910,7 +2644,12 @@ loupe@^3.1.0, loupe@^3.1.4:
   resolved "https://registry.npmjs.org/loupe/-/loupe-3.1.4.tgz"
   integrity sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==
 
-lru-cache@^10.2.0, lru-cache@^10.4.3:
+lru-cache@^10.2.0:
+  version "10.4.3"
+  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
+
+lru-cache@^10.4.3:
   version "10.4.3"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
@@ -2974,13 +2713,6 @@ mime-types@^2.1.12:
   dependencies:
     mime-db "1.52.0"
 
-minimatch@9.0.1:
-  version "9.0.1"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz"
-  integrity sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==
-  dependencies:
-    brace-expansion "^2.0.1"
-
 minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
@@ -2992,6 +2724,13 @@ minimatch@^9.0.4:
   version "9.0.5"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz"
   integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@9.0.1:
+  version "9.0.1"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz"
+  integrity sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==
   dependencies:
     brace-expansion "^2.0.1"
 
@@ -3014,6 +2753,11 @@ mlly@^1.7.4:
     pathe "^2.0.1"
     pkg-types "^1.3.0"
     ufo "^1.5.4"
+
+moment@^2.24.0:
+  version "2.30.1"
+  resolved "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
 mrmime@^2.0.0:
   version "2.0.1"
@@ -3270,7 +3014,7 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-picomatch@^4.0.2:
+"picomatch@^3 || ^4", picomatch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz"
   integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
@@ -3290,7 +3034,7 @@ pinia-plugin-persistedstate@^4.2.0:
     defu "^6.1.4"
     destr "^2.0.3"
 
-pinia@^3.0.2:
+pinia@^3.0.2, pinia@>=2.3.0, pinia@>=3.0.3:
   version "3.0.3"
   resolved "https://registry.npmjs.org/pinia/-/pinia-3.0.3.tgz"
   integrity sha512-ttXO/InUULUXkMHpTdp9Fj4hLpD/2AoJdmAbAeW2yu1iy1k+pkFekQXw5VpC0/5p51IOR/jDaDRfRWRnMMsGOA==
@@ -3322,12 +3066,12 @@ pkg-types@^2.0.0, pkg-types@^2.0.1, pkg-types@^2.1.0:
 
 playwright-core@1.55.0:
   version "1.55.0"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.55.0.tgz#ec8a9f8ef118afb3e86e0f46f1393e3bea32adf4"
+  resolved "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz"
   integrity sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==
 
 playwright@1.55.0:
   version "1.55.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.55.0.tgz#7aca7ac3ffd9e083a8ad8b2514d6f9ba401cc78b"
+  resolved "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz"
   integrity sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==
   dependencies:
     playwright-core "1.55.0"
@@ -3383,7 +3127,7 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.4.14, postcss@^8.4.47, postcss@^8.4.48, postcss@^8.5.3:
+postcss@^8.0.0, postcss@^8.1.0, postcss@^8.2.14, postcss@^8.4.14, postcss@^8.4.21, postcss@^8.4.47, postcss@^8.4.48, postcss@^8.5.3, postcss@>=8.0.9:
   version "8.5.3"
   resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz"
   integrity sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==
@@ -3414,7 +3158,7 @@ prettier-linter-helpers@^1.0.0:
   resolved "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
-prettier@^3.6.2:
+prettier@^3.6.2, "prettier@>= 3.0.0", prettier@>=3.0.0:
   version "3.6.2"
   resolved "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz"
   integrity sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==
@@ -3533,7 +3277,7 @@ rfdc@^1.4.1:
   resolved "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz"
   integrity sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
 
-rollup@^4.30.1:
+rollup@^1.20.0||^2.0.0||^3.0.0||^4.0.0, rollup@^4.34.9:
   version "4.39.0"
   resolved "https://registry.npmjs.org/rollup/-/rollup-4.39.0.tgz"
   integrity sha512-thI8kNc02yNvnmJp8dr3fNWJ9tCONDhp6TV35X6HkKGGs9E6q7YWCHbe5vKiTa7TAiNcFEmXKj3X/pG2b3ci0g==
@@ -3560,35 +3304,6 @@ rollup@^4.30.1:
     "@rollup/rollup-win32-arm64-msvc" "4.39.0"
     "@rollup/rollup-win32-ia32-msvc" "4.39.0"
     "@rollup/rollup-win32-x64-msvc" "4.39.0"
-    fsevents "~2.3.2"
-
-rollup@^4.34.9:
-  version "4.47.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.47.1.tgz#c40bce25b7140265dbe5467cd32871f71e9f9f0b"
-  integrity sha512-iasGAQoZ5dWDzULEUX3jiW0oB1qyFOepSyDyoU6S/OhVlDIwj5knI5QBa5RRQ0sK7OE0v+8VIi2JuV+G+3tfNg==
-  dependencies:
-    "@types/estree" "1.0.8"
-  optionalDependencies:
-    "@rollup/rollup-android-arm-eabi" "4.47.1"
-    "@rollup/rollup-android-arm64" "4.47.1"
-    "@rollup/rollup-darwin-arm64" "4.47.1"
-    "@rollup/rollup-darwin-x64" "4.47.1"
-    "@rollup/rollup-freebsd-arm64" "4.47.1"
-    "@rollup/rollup-freebsd-x64" "4.47.1"
-    "@rollup/rollup-linux-arm-gnueabihf" "4.47.1"
-    "@rollup/rollup-linux-arm-musleabihf" "4.47.1"
-    "@rollup/rollup-linux-arm64-gnu" "4.47.1"
-    "@rollup/rollup-linux-arm64-musl" "4.47.1"
-    "@rollup/rollup-linux-loongarch64-gnu" "4.47.1"
-    "@rollup/rollup-linux-ppc64-gnu" "4.47.1"
-    "@rollup/rollup-linux-riscv64-gnu" "4.47.1"
-    "@rollup/rollup-linux-riscv64-musl" "4.47.1"
-    "@rollup/rollup-linux-s390x-gnu" "4.47.1"
-    "@rollup/rollup-linux-x64-gnu" "4.47.1"
-    "@rollup/rollup-linux-x64-musl" "4.47.1"
-    "@rollup/rollup-win32-arm64-msvc" "4.47.1"
-    "@rollup/rollup-win32-ia32-msvc" "4.47.1"
-    "@rollup/rollup-win32-x64-msvc" "4.47.1"
     fsevents "~2.3.2"
 
 rrweb-cssom@^0.8.0:
@@ -3639,7 +3354,17 @@ semver@^6.3.1:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.5.3, semver@^7.6.3, semver@^7.7.1:
+semver@^7.5.3:
+  version "7.7.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz"
+  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
+
+semver@^7.6.3:
+  version "7.7.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz"
+  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
+
+semver@^7.7.1:
   version "7.7.1"
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz"
   integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
@@ -4046,7 +3771,7 @@ unctx@^2.4.1:
 
 undici-types@~7.10.0:
   version "7.10.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.10.0.tgz#4ac2e058ce56b462b056e629cc6a02393d3ff350"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz"
   integrity sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==
 
 unicorn-magic@^0.3.0:
@@ -4127,18 +3852,18 @@ util-deprecate@^1.0.2:
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-vee-validate@4.15.0:
-  version "4.15.0"
-  resolved "https://registry.npmjs.org/vee-validate/-/vee-validate-4.15.0.tgz"
-  integrity sha512-PGJh1QCFwCBjbHu5aN6vB8macYVWrajbDvgo1Y/8fz9n/RVIkLmZCJDpUgu7+mUmCOPMxeyq7vXUOhbwAqdXcA==
-  dependencies:
-    "@vue/devtools-api" "^7.5.2"
-    type-fest "^4.8.3"
-
 vee-validate@^4.15.1:
   version "4.15.1"
   resolved "https://registry.npmjs.org/vee-validate/-/vee-validate-4.15.1.tgz"
   integrity sha512-DkFsiTwEKau8VIxyZBGdO6tOudD+QoUBPuHj3e6QFqmbfCRj1ArmYWue9lEp6jLSWBIw4XPlDLjFIZNLdRAMSg==
+  dependencies:
+    "@vue/devtools-api" "^7.5.2"
+    type-fest "^4.8.3"
+
+vee-validate@4.15.0:
+  version "4.15.0"
+  resolved "https://registry.npmjs.org/vee-validate/-/vee-validate-4.15.0.tgz"
+  integrity sha512-PGJh1QCFwCBjbHu5aN6vB8macYVWrajbDvgo1Y/8fz9n/RVIkLmZCJDpUgu7+mUmCOPMxeyq7vXUOhbwAqdXcA==
   dependencies:
     "@vue/devtools-api" "^7.5.2"
     type-fest "^4.8.3"
@@ -4202,20 +3927,9 @@ vite-plugin-vue-inspector@^5.3.1:
     kolorist "^1.8.0"
     magic-string "^0.30.4"
 
-"vite@^5.0.0 || ^6.0.0 || ^7.0.0-0", vite@^6.2.0:
-  version "6.2.5"
-  resolved "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz"
-  integrity sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==
-  dependencies:
-    esbuild "^0.25.0"
-    postcss "^8.5.3"
-    rollup "^4.30.1"
-  optionalDependencies:
-    fsevents "~2.3.3"
-
-vite@^6.3.4:
+"vite@^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0", "vite@^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.0-0", "vite@^3.1.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.1", "vite@^3.1.0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.0-0", "vite@^5.0.0 || ^6.0.0", "vite@^5.0.0 || ^6.0.0 || ^7.0.0-0", vite@^6.2.0, vite@^6.3.4:
   version "6.3.5"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-6.3.5.tgz#fec73879013c9c0128c8d284504c6d19410d12a3"
+  resolved "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz"
   integrity sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==
   dependencies:
     esbuild "^0.25.0"
@@ -4227,7 +3941,7 @@ vite@^6.3.4:
   optionalDependencies:
     fsevents "~2.3.3"
 
-vitest@^3.2.4:
+vitest@^3.2.4, vitest@3.2.4:
   version "3.2.4"
   resolved "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz"
   integrity sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==
@@ -4261,6 +3975,18 @@ vue-component-type-helpers@^2.0.0:
   resolved "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.2.12.tgz"
   integrity sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==
 
+vue-eslint-parser@^10.0.0, vue-eslint-parser@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-10.2.0.tgz"
+  integrity sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==
+  dependencies:
+    debug "^4.4.0"
+    eslint-scope "^8.2.0"
+    eslint-visitor-keys "^4.2.0"
+    espree "^10.3.0"
+    esquery "^1.6.0"
+    semver "^7.6.3"
+
 vue-i18n@10:
   version "10.0.7"
   resolved "https://registry.npmjs.org/vue-i18n/-/vue-i18n-10.0.7.tgz"
@@ -4277,7 +4003,7 @@ vue-router@4:
   dependencies:
     "@vue/devtools-api" "^6.6.4"
 
-vue@^2.3.3:
+vue@^2.3.3, vue@^2.5.18:
   version "2.7.16"
   resolved "https://registry.npmjs.org/vue/-/vue-2.7.16.tgz"
   integrity sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==
@@ -4285,7 +4011,7 @@ vue@^2.3.3:
     "@vue/compiler-sfc" "2.7.16"
     csstype "^3.1.0"
 
-vue@^3.5.13:
+"vue@^2.7.0 || ^3.0.0", "vue@^2.7.0 || ^3.5.11", vue@^3.0.0, vue@^3.0.11, vue@^3.2.0, vue@^3.2.25, vue@^3.4.26, vue@^3.5.0, vue@^3.5.13, "vue@>= 3", vue@3.5.13:
   version "3.5.13"
   resolved "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz"
   integrity sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==
@@ -4440,7 +4166,7 @@ yallist@^3.0.2:
   resolved "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
-yaml@^2.3.4:
+yaml@^2.3.4, yaml@^2.4.2:
   version "2.7.1"
   resolved "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz"
   integrity sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==
@@ -4465,7 +4191,7 @@ yup@^1.6.1:
     toposort "^2.0.2"
     type-fest "^2.19.0"
 
-zod@^3.24.3:
+zod@^3.24.0, zod@^3.24.3:
   version "3.24.3"
   resolved "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz"
   integrity sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==


### PR DESCRIPTION
# Revisar todas las variables que el linter marcar como useless #25

## `npm run format`
Ejecuta el formateador de código (generalmente configurado con `Prettier`
).
Este comando recorre todo el proyecto y aplica automáticamente las reglas de estilo definidas, como:
1. Indentación uniforme.
2. Uso consistente de comillas (simples o dobles).
3. Orden correcto de imports.
4. Eliminación de espacios en blanco innecesarios.
5. Que cada archivo termine con salto de línea.

👉 Sirve para mantener un estilo de código consistente y legible en todo el proyecto.
## `npm run lint -- --fix`
Ejecuta el linter (casi siempre configurado con `ESLint`
).
Este comando analiza el código en busca de problemas como:
1. Errores de sintaxis.
2. Variables no usadas.
3. Reglas de buenas prácticas no cumplidas.
4. Posibles errores lógicos.

Con la opción --fix, además de señalar problemas, intenta corregir automáticamente aquellos que tienen solución segura (por ejemplo, reordenar imports, cambiar comillas, agregar punto y coma).

👉 Ayuda a detectar errores antes de que el código se ejecute y asegura que siga las reglas del proyecto.
