### PR TITLE
[bug] quitar import innecesario para deploy

### DIFF
--- a/frontend-app/src/utils/fileAdapter.js
+++ b/frontend-app/src/utils/fileAdapter.js
@@ -1,4 +1,3 @@
-import { Blob } from 'buffer';
 export class FileAdapter {
   constructor(source, options = {}) {
     this.source = source;


### PR DESCRIPTION
## 🚀 Fix: Resolver error de build en producción

### Problema
El build de producción fallaba al intentar compilar `fileAdapter.js` debido a un import incorrecto del módulo `buffer` de Node.js, que no existe en entornos de navegador.

### Solución
- Eliminada línea `import { Blob } from 'buffer';` en `src/utils/fileAdapter.js`
- `Blob` ya está disponible nativamente en todos los navegadores modernos como API global
- No requiere importación explícita

### Cambios
- ✅ Build de producción exitoso
- ✅ Funcionalidad de `FileAdapter` intacta
- ✅ Compatible con entornos de navegador

### Testing
- Probado en producción con Docker + Nginx
- Aplicación desplegada y funcionando correctamente en Azure